### PR TITLE
Cluster-aware MomentWildBootstrap + loky-safe weight_scheme (#7)

### DIFF
--- a/src/manifoldgmm/econometrics/bootstrap.py
+++ b/src/manifoldgmm/econometrics/bootstrap.py
@@ -218,45 +218,68 @@ class BootstrapTask:
         Starting point for the optimizer (typically :math:`\\hat\\theta`).
     seed : int
         RNG seed for weight generation.
-    weight_scheme : str
-        Name of the weight distribution (``"rademacher"``, ``"mammen"``, or
-        ``"exponential"``).
+    weight_scheme : str or callable
+        Either the name of a built-in distribution (``"rademacher"``,
+        ``"mammen"``, ``"exponential"``) or a callable
+        ``(n, rng) -> np.ndarray`` of shape ``(n,)`` with ``E[w] = 1``.
+        Callables ride through the pickled payload, so user-defined schemes
+        do not depend on parent-process mutations of the module-level
+        registry surviving the fork to a loky worker.
     optimizer_class : type or None
         Optimizer class to use (default: pymanopt TrustRegions).
     optimizer_kwargs : dict
         Extra keyword arguments forwarded to the optimizer constructor.
     task_id : int
         Integer identifying this replicate.
+    cluster_codes : numpy.ndarray or None
+        Integer cluster codes of length ``N`` (one per observation), or
+        ``None`` for the i.i.d. scheme.  When provided, one wild weight is
+        drawn per unique cluster and broadcast to its member rows.
+    num_clusters : int or None
+        Number of unique clusters ``G`` (matches
+        ``cluster_codes.max() + 1``).  Required when ``cluster_codes`` is set.
     """
 
     restriction: MomentRestriction
     weighting_matrix: Any
     initial_point: Any
     seed: int
-    weight_scheme: str
+    weight_scheme: str | Callable[[int, np.random.Generator], np.ndarray]
     optimizer_class: type | None
     optimizer_kwargs: dict[str, Any]
     task_id: int
+    cluster_codes: np.ndarray | None = None
+    num_clusters: int | None = None
 
     def run(self) -> BootstrapResult:
         """Execute the bootstrap replicate (worker entry point).
 
         Steps
         -----
-        1. Generate observation weights from ``seed`` using the named scheme.
-        2. Create a weighted clone via ``restriction.with_weights(w)``.
-        3. Construct a ``GMM`` estimator with ``FixedWeighting(W)`` and run it.
-        4. Return a lightweight ``BootstrapResult``.
+        1. Resolve the weight generator from ``weight_scheme`` (callable
+           used directly, string looked up in the built-in registry).
+        2. Draw ``N`` i.i.d. weights, or ``G`` cluster-constant weights
+           broadcast via ``cluster_codes`` when set.
+        3. Create a weighted clone via ``restriction.with_weights(w)``,
+           chaining ``with_clusters`` when the parent restriction carries
+           a cluster assignment.
+        4. Construct a ``GMM`` estimator with ``FixedWeighting(W)`` and run it.
+        5. Return a lightweight ``BootstrapResult``.
         """
 
         rng = np.random.default_rng(self.seed)
 
-        generator = _WEIGHT_GENERATORS.get(self.weight_scheme)
-        if generator is None:
-            raise ValueError(
-                f"Unknown weight scheme {self.weight_scheme!r}; "
-                f"choose from {sorted(_WEIGHT_GENERATORS)}"
-            )
+        scheme = self.weight_scheme
+        if callable(scheme):
+            generator = scheme
+        else:
+            generator = _WEIGHT_GENERATORS.get(scheme)
+            if generator is None:
+                raise ValueError(
+                    f"Unknown weight scheme {scheme!r}; "
+                    f"choose from {sorted(_WEIGHT_GENERATORS)} "
+                    f"or pass a callable (n, rng) -> np.ndarray."
+                )
 
         n = self.restriction.num_observations
         if n is None:
@@ -265,8 +288,28 @@ class BootstrapTask:
                 "evaluate the restriction at a point first."
             )
 
-        weights = generator(n, rng)
+        if self.cluster_codes is None:
+            weights = generator(n, rng)
+        else:
+            codes = self.cluster_codes
+            if codes.shape != (n,):
+                raise ValueError(
+                    f"cluster_codes shape {codes.shape} does not match "
+                    f"num_observations ({n},)"
+                )
+            if self.num_clusters is None:
+                raise RuntimeError(
+                    "cluster_codes was supplied without num_clusters; "
+                    "construct BootstrapTask via MomentWildBootstrap."
+                )
+            cluster_weights = generator(self.num_clusters, rng)
+            weights = np.asarray(cluster_weights)[codes]
+
         weighted_restriction = self.restriction.with_weights(weights)
+        if self.restriction.clusters is not None:
+            weighted_restriction = weighted_restriction.with_clusters(
+                self.restriction.clusters
+            )
 
         optimizer_kwargs = dict(self.optimizer_kwargs)
         optimizer_kwargs.setdefault("verbosity", 0)
@@ -518,15 +561,37 @@ class MomentWildBootstrap:
         weighting matrix, and the moment restriction.
     n_bootstrap : int
         Number of bootstrap replicates.
-    weight_scheme : str, default ``"rademacher"``
-        Weight distribution: ``"rademacher"``, ``"mammen"``, or
-        ``"exponential"``.
+    weight_scheme : str or callable, default ``"rademacher"``
+        Either the name of a built-in scheme (``"rademacher"``, ``"mammen"``,
+        ``"exponential"``) or a callable ``(n, rng) -> np.ndarray`` of shape
+        ``(n,)`` with ``E[w] = 1``.  Callables are pickled into the task
+        payload, avoiding the loky-worker hazard of relying on parent-process
+        mutations of the module-level registry surviving a fork.
+    clusters : array-like or None, default ``None``
+        Optional cluster ids of length ``N``.  When supplied (or inherited
+        from ``gmm_result.restriction.clusters`` if that is non-``None``),
+        each replicate draws one wild weight per unique cluster and
+        broadcasts it to the cluster's member rows.  Replicate restrictions
+        also inherit the cluster assignment so their :math:`\hat\Omega` is
+        cluster-robust.  With clusters of size 1 this reduces to the
+        per-observation scheme byte-for-byte.
     base_seed : int, default 0
         Base random seed; replicate *b* uses seed ``base_seed + b``.
     optimizer_class : type or None
         Optimizer class forwarded to each task.
     optimizer_kwargs : dict or None
         Extra optimizer keyword arguments.
+
+    Notes
+    -----
+    Under the cluster bootstrap, the effective sample size is the number
+    of clusters ``G``, not ``N``.  ``n_bootstrap`` should be set with this
+    in mind: with small ``G`` (say, < 30) the bootstrap distribution is
+    coarse and quantile estimates noisy regardless of how many replicates
+    are taken.  When ``weight_scheme=`` is a callable, it must be picklable
+    by the chosen executor (cloudpickle is used as a fallback by
+    :meth:`BootstrapTask.to_bytes`; loky workers carry their own pickling
+    semantics, so closures over unpicklable state should be avoided).
     """
 
     def __init__(
@@ -534,15 +599,25 @@ class MomentWildBootstrap:
         gmm_result: GMMResult,
         n_bootstrap: int = 199,
         *,
-        weight_scheme: str = "rademacher",
+        weight_scheme: str
+        | Callable[[int, np.random.Generator], np.ndarray] = "rademacher",
+        clusters: Any | None = None,
         base_seed: int = 0,
         optimizer_class: type | None = None,
         optimizer_kwargs: Mapping[str, Any] | None = None,
     ) -> None:
-        if weight_scheme not in _WEIGHT_GENERATORS:
-            raise ValueError(
-                f"Unknown weight_scheme {weight_scheme!r}; "
-                f"choose from {sorted(_WEIGHT_GENERATORS)}"
+        if isinstance(weight_scheme, str):
+            if weight_scheme not in _WEIGHT_GENERATORS:
+                raise ValueError(
+                    f"Unknown weight_scheme {weight_scheme!r}; "
+                    f"choose from {sorted(_WEIGHT_GENERATORS)} "
+                    f"or pass a callable (n, rng) -> np.ndarray."
+                )
+        elif not callable(weight_scheme):
+            raise TypeError(
+                "weight_scheme must be a str name or a callable "
+                "(n, rng) -> np.ndarray; got "
+                f"{type(weight_scheme).__name__}."
             )
 
         self._gmm_result = gmm_result
@@ -551,6 +626,40 @@ class MomentWildBootstrap:
         self._base_seed = base_seed
         self._optimizer_class = optimizer_class
         self._optimizer_kwargs = dict(optimizer_kwargs or {})
+
+        # Resolve cluster assignment: explicit `clusters=` wins; otherwise
+        # inherit from the restriction so the natural usage (clustered
+        # GMMResult -> clustered bootstrap) just works.  We carry the
+        # resolved ids in one place (`self._cluster_ids`) and attach them
+        # to the task-side restriction in `tasks()`.
+        restriction = gmm_result.restriction
+        cluster_source = clusters if clusters is not None else restriction.clusters
+
+        if cluster_source is None:
+            self._cluster_ids: Any | None = None
+            self._cluster_codes: np.ndarray | None = None
+            self._num_clusters: int | None = None
+        else:
+            cluster_arr = np.asarray(cluster_source)
+            if cluster_arr.ndim != 1:
+                raise ValueError(
+                    "clusters must be a 1-D array of length N; "
+                    f"got shape {cluster_arr.shape}."
+                )
+            n_obs = restriction.num_observations
+            if n_obs is not None and cluster_arr.shape[0] != n_obs:
+                raise ValueError(
+                    f"clusters length ({cluster_arr.shape[0]}) does not "
+                    f"match restriction.num_observations ({n_obs})."
+                )
+            _, codes = np.unique(cluster_arr, return_inverse=True)
+            self._cluster_ids = cluster_source
+            self._cluster_codes = codes.astype(np.int64, copy=False)
+            self._num_clusters = (
+                int(self._cluster_codes.max()) + 1
+                if self._cluster_codes.size > 0
+                else 0
+            )
 
         # Extract a fixed weighting matrix W evaluated at theta_hat
         weighting: Any = gmm_result.weighting
@@ -584,6 +693,14 @@ class MomentWildBootstrap:
         """
 
         restriction = self._gmm_result.restriction
+        # Attach the resolved cluster ids to the task-side restriction if
+        # the bootstrap is operating in clustered mode and the original
+        # restriction did not already carry the same assignment.  This
+        # ensures `BootstrapTask.run`'s `with_clusters` chaining produces a
+        # cluster-robust replicate Omega for every replicate.
+        if self._cluster_ids is not None and restriction.clusters is None:
+            restriction = restriction.with_clusters(self._cluster_ids)
+
         theta_hat = self._gmm_result.theta_point
         # Use the ambient value as initial point for each replicate
         initial_point = theta_hat.value
@@ -598,6 +715,8 @@ class MomentWildBootstrap:
                 optimizer_class=self._optimizer_class,
                 optimizer_kwargs=self._optimizer_kwargs,
                 task_id=b,
+                cluster_codes=self._cluster_codes,
+                num_clusters=self._num_clusters,
             )
             for b in range(self._n_bootstrap)
         ]

--- a/src/manifoldgmm/econometrics/bootstrap.py
+++ b/src/manifoldgmm/econometrics/bootstrap.py
@@ -270,16 +270,18 @@ class BootstrapTask:
         rng = np.random.default_rng(self.seed)
 
         scheme = self.weight_scheme
+        generator: Callable[[int, np.random.Generator], np.ndarray]
         if callable(scheme):
             generator = scheme
         else:
-            generator = _WEIGHT_GENERATORS.get(scheme)
-            if generator is None:
+            try:
+                generator = _WEIGHT_GENERATORS[scheme]
+            except KeyError:
                 raise ValueError(
                     f"Unknown weight scheme {scheme!r}; "
                     f"choose from {sorted(_WEIGHT_GENERATORS)} "
                     f"or pass a callable (n, rng) -> np.ndarray."
-                )
+                ) from None
 
         n = self.restriction.num_observations
         if n is None:
@@ -599,8 +601,9 @@ class MomentWildBootstrap:
         gmm_result: GMMResult,
         n_bootstrap: int = 199,
         *,
-        weight_scheme: str
-        | Callable[[int, np.random.Generator], np.ndarray] = "rademacher",
+        weight_scheme: (
+            str | Callable[[int, np.random.Generator], np.ndarray]
+        ) = "rademacher",
         clusters: Any | None = None,
         base_seed: int = 0,
         optimizer_class: type | None = None,

--- a/tests/econometrics/test_bootstrap.py
+++ b/tests/econometrics/test_bootstrap.py
@@ -17,6 +17,7 @@ from manifoldgmm.econometrics.bootstrap import (
     BootstrapTask,
     MomentWildBootstrap,
     exponential_weights,
+    geodesic_mahalanobis_distance,
     mammen_weights,
     rademacher_weights,
 )
@@ -317,3 +318,642 @@ class TestEndToEndIntegration:
 
         with pytest.raises(ValueError, match="Unknown weight_scheme"):
             MomentWildBootstrap(result, weight_scheme="unknown")
+
+
+# -----------------------------------------------------------------------
+# 7. Cluster-aware bootstrap: structural + API
+# -----------------------------------------------------------------------
+
+
+def _clustered_restriction_and_result(
+    cluster_ids: np.ndarray,
+    data: Any | None = None,
+    *,
+    attach_clusters: bool = False,
+) -> tuple[Any, Any, np.ndarray]:
+    """Build a clustered Euclidean(1) mean-estimation problem and solve it.
+
+    ``cluster_ids`` is returned as the canonical cluster assignment.  When
+    ``attach_clusters=True`` the restriction itself carries the assignment;
+    otherwise the restriction is unclustered (the bootstrap will need an
+    explicit ``clusters=`` argument).
+    """
+
+    if data is None:
+        n = cluster_ids.shape[0]
+        data = jnp.arange(1.0, n + 1.0, dtype=jnp.float64)
+
+    def gi_jax(theta: Any, observation: Any) -> Any:
+        return observation - theta[0]
+
+    manifold = Manifold.from_pymanopt(PymanoptEuclidean(1))
+    kwargs: dict[str, Any] = {
+        "gi_jax": gi_jax,
+        "data": data,
+        "manifold": manifold,
+        "backend": "jax",
+    }
+    if attach_clusters:
+        kwargs["clusters"] = cluster_ids
+    restriction = MomentRestriction(**kwargs)
+    gmm = GMM(restriction, initial_point=jnp.array([0.0]))
+    result = gmm.estimate()
+    return restriction, result, cluster_ids
+
+
+class TestClusterStructural:
+    """Structural and API behaviour of the cluster-aware bootstrap."""
+
+    def test_clusters_size_one_byte_identical_to_iid(self) -> None:
+        """Regression invariant: G = N (singleton clusters) reproduces the i.i.d. path.
+
+        With cluster ids ``0..N-1`` and the same ``base_seed`` and
+        ``weight_scheme``, the cluster path draws ``G = N`` weights from the
+        same RNG state and broadcasts them via ``codes = arange(N)``.  The
+        ``theta_star`` trajectory must match the unclustered path exactly.
+        """
+
+        _, result, _ = _simple_restriction_and_result()
+        n = result.restriction.num_observations
+
+        boot_iid = MomentWildBootstrap(result, n_bootstrap=8, base_seed=42)
+        res_iid = boot_iid.run_sequential()
+
+        cluster_ids = np.arange(n)
+        boot_clus = MomentWildBootstrap(
+            result, n_bootstrap=8, clusters=cluster_ids, base_seed=42
+        )
+        res_clus = boot_clus.run_sequential()
+
+        iid_thetas = np.array(
+            [float(np.asarray(r.theta_star.value).ravel()[0]) for r in res_iid]
+        )
+        clus_thetas = np.array(
+            [float(np.asarray(r.theta_star.value).ravel()[0]) for r in res_clus]
+        )
+        np.testing.assert_array_equal(iid_thetas, clus_thetas)
+
+    def test_callable_scheme_called_with_G_in_cluster_mode(self) -> None:
+        """When ``clusters=`` is set, the weight generator is called with G, not N.
+
+        Indirect verification of the broadcast: the per-cluster scheme draws
+        ``G`` weights; the unclustered path draws ``N``.
+        """
+
+        cluster_ids = np.repeat(np.arange(3), 4)  # 12 obs in 3 clusters of size 4
+        _, result, _ = _clustered_restriction_and_result(cluster_ids)
+
+        captured: list[int] = []
+
+        def recording_scheme(n: int, rng: np.random.Generator) -> np.ndarray:
+            captured.append(n)
+            return rng.uniform(size=n)
+
+        boot = MomentWildBootstrap(
+            result,
+            n_bootstrap=2,
+            clusters=cluster_ids,
+            weight_scheme=recording_scheme,
+            base_seed=0,
+        )
+        boot.run_sequential()
+
+        assert captured == [3, 3], (
+            "scheme should be called with G=3 once per replicate, "
+            f"got {captured}"
+        )
+
+    def test_weights_constant_within_cluster(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The weights handed to ``with_weights`` are cluster-constant."""
+
+        cluster_ids = np.repeat(np.arange(3), 4)  # 12 obs / 3 clusters / size 4
+        _, result, _ = _clustered_restriction_and_result(cluster_ids)
+
+        from manifoldgmm.econometrics import moment_restriction as mr_mod
+
+        original_with_weights = mr_mod.MomentRestriction.with_weights
+        captured_weights: list[np.ndarray] = []
+
+        def spy_with_weights(self: Any, w: Any) -> Any:
+            captured_weights.append(np.asarray(w).copy())
+            return original_with_weights(self, w)
+
+        monkeypatch.setattr(
+            mr_mod.MomentRestriction, "with_weights", spy_with_weights
+        )
+
+        boot = MomentWildBootstrap(
+            result, n_bootstrap=2, clusters=cluster_ids, base_seed=0
+        )
+        boot.run_sequential()
+
+        assert len(captured_weights) == 2
+        for w in captured_weights:
+            assert w.shape == (12,)
+            for c in range(3):
+                mask = cluster_ids == c
+                unique_vals = np.unique(w[mask])
+                assert unique_vals.size == 1, (
+                    f"weights not cluster-constant for cluster {c}: "
+                    f"{w[mask]}"
+                )
+
+    def test_auto_default_from_restriction_clusters(self) -> None:
+        """If the restriction carries ``.clusters``, the bootstrap auto-uses it."""
+
+        cluster_ids = np.repeat(np.arange(4), 3)  # 12 obs in 4 clusters
+        _, result, _ = _clustered_restriction_and_result(
+            cluster_ids, attach_clusters=True
+        )
+
+        # No explicit clusters= argument -- should still pick up the parent
+        boot = MomentWildBootstrap(result, n_bootstrap=3, base_seed=0)
+
+        assert boot._cluster_codes is not None
+        assert boot._cluster_codes.shape == (12,)
+        assert boot._num_clusters == 4
+
+        # Verify it's actually used by checking the scheme is called with G=4
+        captured: list[int] = []
+
+        def recording_scheme(n: int, rng: np.random.Generator) -> np.ndarray:
+            captured.append(n)
+            return rng.uniform(size=n)
+
+        boot2 = MomentWildBootstrap(
+            result,
+            n_bootstrap=2,
+            weight_scheme=recording_scheme,
+            base_seed=0,
+        )
+        boot2.run_sequential()
+        assert captured == [4, 4]
+
+    def test_explicit_clusters_override_restriction(self) -> None:
+        """An explicit ``clusters=`` argument overrides any inherited assignment."""
+
+        inherited_ids = np.repeat(np.arange(4), 3)  # G=4
+        override_ids = np.repeat(np.arange(2), 6)  # G=2
+        _, result, _ = _clustered_restriction_and_result(
+            inherited_ids, attach_clusters=True
+        )
+
+        captured: list[int] = []
+
+        def recording_scheme(n: int, rng: np.random.Generator) -> np.ndarray:
+            captured.append(n)
+            return rng.uniform(size=n)
+
+        boot = MomentWildBootstrap(
+            result,
+            n_bootstrap=2,
+            clusters=override_ids,
+            weight_scheme=recording_scheme,
+            base_seed=0,
+        )
+        boot.run_sequential()
+        assert captured == [2, 2], (
+            "explicit clusters= should take precedence over inherited; "
+            f"got n={captured}"
+        )
+
+    def test_task_restriction_carries_clusters(self) -> None:
+        """``BootstrapTask.restriction.clusters`` is set in clustered mode.
+
+        This ensures the ``with_clusters`` chain in ``BootstrapTask.run``
+        fires and the replicate :math:`\\hat\\Omega` is cluster-robust.
+        """
+
+        cluster_ids = np.repeat(np.arange(3), 4)
+        _, result, _ = _clustered_restriction_and_result(cluster_ids)
+
+        boot = MomentWildBootstrap(
+            result, n_bootstrap=1, clusters=cluster_ids, base_seed=0
+        )
+        task = boot.tasks()[0]
+        assert task.restriction.clusters is not None
+        assert task.cluster_codes is not None
+        assert task.num_clusters == 3
+
+    def test_callable_scheme_pickle_round_trip(self) -> None:
+        """A callable ``weight_scheme`` survives ``BootstrapTask.to_bytes``."""
+
+        cluster_ids = np.repeat(np.arange(3), 4)
+        _, result, _ = _clustered_restriction_and_result(cluster_ids)
+
+        # Use the module-level helper (picklable) as the scheme
+        boot = MomentWildBootstrap(
+            result,
+            n_bootstrap=1,
+            clusters=cluster_ids,
+            weight_scheme=exponential_weights,
+            base_seed=11,
+        )
+        task = boot.tasks()[0]
+
+        # Round trip
+        data = task.to_bytes()
+        revived = BootstrapTask.from_bytes(data)
+        assert callable(revived.weight_scheme)
+        # Same RNG state should yield identical weights
+        n_clusters = revived.num_clusters
+        assert n_clusters is not None
+        rng1 = np.random.default_rng(123)
+        rng2 = np.random.default_rng(123)
+        w1 = task.weight_scheme(n_clusters, rng1)  # type: ignore[operator]
+        w2 = revived.weight_scheme(n_clusters, rng2)  # type: ignore[operator]
+        np.testing.assert_array_equal(w1, w2)
+
+        # End-to-end run also succeeds via the revived task
+        revived_result = revived.run()
+        assert isinstance(revived_result, BootstrapResult)
+
+    def test_callable_scheme_replaces_registry(self) -> None:
+        """A user-defined callable bypasses ``_WEIGHT_GENERATORS`` entirely.
+
+        Regression guard for the loky-fork hazard: the worker path must not
+        depend on parent-process mutations of the module-level registry.
+        """
+
+        cluster_ids = np.repeat(np.arange(2), 3)  # 6 obs / 2 clusters / size 3
+        _, result, _ = _clustered_restriction_and_result(cluster_ids)
+
+        # A scheme NOT in _WEIGHT_GENERATORS; bootstrap accepts it directly.
+        def custom_scheme(n: int, rng: np.random.Generator) -> np.ndarray:
+            # E[w] = 1, Var[w] = 1; values in {1 - sqrt(3), 1, 1 + sqrt(3)}
+            return rng.choice(
+                [1.0 - np.sqrt(3.0), 1.0, 1.0 + np.sqrt(3.0)],
+                size=n,
+                p=[1 / 6, 2 / 3, 1 / 6],
+            )
+
+        boot = MomentWildBootstrap(
+            result,
+            n_bootstrap=3,
+            clusters=cluster_ids,
+            weight_scheme=custom_scheme,
+            base_seed=0,
+        )
+        results = boot.run_sequential()
+        assert len(results) == 3
+        # All replicates should produce finite theta_star values
+        for r in results:
+            assert np.isfinite(float(np.asarray(r.theta_star.value).ravel()[0]))
+
+    def test_invalid_weight_scheme_type_raises(self) -> None:
+        """Non-str, non-callable ``weight_scheme`` raises TypeError."""
+
+        _, result, _ = _simple_restriction_and_result()
+
+        with pytest.raises(TypeError, match="weight_scheme must be"):
+            MomentWildBootstrap(result, weight_scheme=42)  # type: ignore[arg-type]
+
+    def test_clusters_wrong_shape_raises(self) -> None:
+        """``clusters=`` with shape mismatched to N raises ValueError."""
+
+        _, result, _ = _simple_restriction_and_result()
+
+        with pytest.raises(ValueError, match="clusters length"):
+            MomentWildBootstrap(
+                result, clusters=np.arange(99), n_bootstrap=1, base_seed=0
+            )
+
+    def test_clusters_non_1d_raises(self) -> None:
+        """``clusters=`` with ndim != 1 raises ValueError."""
+
+        _, result, _ = _simple_restriction_and_result()
+
+        with pytest.raises(ValueError, match="1-D array"):
+            MomentWildBootstrap(
+                result,
+                clusters=np.zeros((5, 2)),
+                n_bootstrap=1,
+                base_seed=0,
+            )
+
+
+# -----------------------------------------------------------------------
+# 8. Cluster-aware bootstrap: variance inflation smoke test
+# -----------------------------------------------------------------------
+
+
+class TestClusterVarianceInflation:
+    """Smoke-grade: cluster bootstrap distribution is wider than i.i.d. on clustered data."""
+
+    def test_cluster_sd_exceeds_iid_sd(self) -> None:
+        """On clustered DGP, the bootstrap SD of ``theta_star`` is larger
+        under the cluster scheme than the i.i.d. scheme.
+
+        This is the bootstrap-distribution analogue of the SE inflation
+        established for ``omega_hat`` in PR #5; it is a necessary (but not
+        sufficient) condition for correct CR coverage.  The full coverage
+        check is in :class:`TestClusterMonteCarlo` below, marked slow.
+        """
+
+        rng = np.random.default_rng(0)
+        G, m = 20, 8  # 160 observations
+        sigma_u, sigma_e = 1.0, 0.5
+        u = rng.normal(scale=sigma_u, size=G)
+        e = rng.normal(scale=sigma_e, size=(G, m))
+        X = (u[:, None] + e).ravel()
+        cluster_ids = np.repeat(np.arange(G), m)
+
+        data = jnp.array(X)
+        _, result, _ = _clustered_restriction_and_result(cluster_ids, data=data)
+
+        boot_iid = MomentWildBootstrap(result, n_bootstrap=200, base_seed=1)
+        boot_iid.run_sequential()
+        iid_sd = float(
+            np.std(
+                [
+                    float(np.asarray(r.theta_star.value).ravel()[0])
+                    for r in boot_iid._results
+                ]
+            )
+        )
+
+        boot_clus = MomentWildBootstrap(
+            result, n_bootstrap=200, clusters=cluster_ids, base_seed=1
+        )
+        boot_clus.run_sequential()
+        clus_sd = float(
+            np.std(
+                [
+                    float(np.asarray(r.theta_star.value).ravel()[0])
+                    for r in boot_clus._results
+                ]
+            )
+        )
+
+        # Theoretical ratio: sqrt((sigma_u^2 + sigma_e^2/m)*N / (sigma_u^2 + sigma_e^2))
+        # = sqrt((1.0 + 0.25/8) * 160 / 1.25) ~= sqrt(132) ~= 11.5... no wait,
+        # the i.i.d. bootstrap recovers an estimator of (sigma_u^2 + sigma_e^2)/N,
+        # whereas the cluster bootstrap targets (sigma_u^2 + sigma_e^2/m)/G.
+        # Ratio of SDs:
+        #   cluster / iid = sqrt(((sigma_u^2 + sigma_e^2/m)/G)
+        #                        / ((sigma_u^2 + sigma_e^2)/N))
+        #                 = sqrt((1.03125/20) / (1.25/160))
+        #                 = sqrt(0.0515625 / 0.0078125)
+        #                 = sqrt(6.6) ~= 2.57
+        # Use a loose lower bound of 1.5 to absorb 200-replicate noise.
+        assert clus_sd > 1.5 * iid_sd, (
+            f"cluster SD ({clus_sd:.4f}) should exceed 1.5x iid SD "
+            f"({iid_sd:.4f}); ratio {clus_sd / iid_sd:.2f}"
+        )
+
+
+# -----------------------------------------------------------------------
+# 9. Cluster-aware bootstrap: size, power, and i.i.d.-under-coverage MC
+# -----------------------------------------------------------------------
+
+
+def _draw_clustered_panel(
+    rng: np.random.Generator,
+    mu: float,
+    G: int,
+    m: int,
+    sigma_u: float,
+    sigma_e: float,
+) -> tuple[Any, np.ndarray]:
+    """Draw a panel with G clusters of size m and within-cluster correlation.
+
+    ``X_{c,i} = mu + u_c + e_{c,i}`` with ``u_c ~ N(0, sigma_u^2)``,
+    ``e_{c,i} ~ N(0, sigma_e^2)``.  Returns ``(data_jax, cluster_ids)``.
+    """
+
+    u = rng.normal(scale=sigma_u, size=G)
+    e = rng.normal(scale=sigma_e, size=(G, m))
+    X = mu + u[:, None] + e
+    cluster_ids = np.repeat(np.arange(G), m)
+    return jnp.array(X.ravel(), dtype=jnp.float64), cluster_ids
+
+
+def _fit_and_bootstrap(
+    data: Any,
+    cluster_ids: np.ndarray,
+    *,
+    n_bootstrap: int,
+    base_seed: int,
+    use_clusters_in_bootstrap: bool,
+) -> tuple[Any, Any, np.ndarray]:
+    """Fit cluster-robust GMM on the panel and run a wild bootstrap.
+
+    The parent GMM always carries cluster ids so that the analytic
+    ``Sigma`` returned by ``tangent_covariance`` is the cluster-robust
+    (true) one.  Only the bootstrap weight scheme is toggled by
+    ``use_clusters_in_bootstrap``: when False, the wild draws are i.i.d.
+    per observation (the pre-fix bug); when True, they are cluster-
+    constant.
+
+    Returns ``(result, boot, sigma_cluster)``.  Callers should use
+    ``sigma_cluster`` as the explicit ``covariance=`` argument to
+    ``geodesic_mahalanobis_distance`` and ``boot.geodesic_distances`` so
+    that the cluster-vs-iid contrast isolates the bootstrap scheme
+    rather than entangling it with the analytic-Sigma estimator.
+    """
+
+    def gi_jax(theta: Any, observation: Any) -> Any:
+        return observation - theta[0]
+
+    manifold = Manifold.from_pymanopt(PymanoptEuclidean(1))
+    restriction = MomentRestriction(
+        gi_jax=gi_jax,
+        data=data,
+        manifold=manifold,
+        backend="jax",
+        clusters=cluster_ids,
+    )
+    gmm = GMM(restriction, initial_point=jnp.array([0.0]))
+    result = gmm.estimate()
+    sigma_cluster = np.asarray(
+        result.tangent_covariance().to_numpy(dtype=float)
+    )
+
+    if use_clusters_in_bootstrap:
+        boot = MomentWildBootstrap(
+            result, n_bootstrap=n_bootstrap, base_seed=base_seed
+        )
+    else:
+        # Build a parallel result whose restriction lacks clusters so the
+        # bootstrap's auto-default falls back to per-observation draws.
+        # We do NOT use this result's analytic Sigma below; callers pass
+        # ``sigma_cluster`` explicitly to keep the contrast clean.
+        from dataclasses import replace as dc_replace
+
+        bare_restriction = restriction.with_clusters(None)  # type: ignore[arg-type]
+        bare_result = dc_replace(result, restriction=bare_restriction)
+        boot = MomentWildBootstrap(
+            bare_result, n_bootstrap=n_bootstrap, base_seed=base_seed
+        )
+
+    boot.run_sequential()
+    return result, boot, sigma_cluster
+
+
+class TestClusterMonteCarlo:
+    """Slow MC tests: size, power, and i.i.d.-under-coverage on a clustered DGP.
+
+    Parameters chosen so that the i.i.d. wild bootstrap is severely
+    under-sized (intra-cluster correlation rho ~= 0.8) and the cluster
+    bootstrap recovers correct coverage.  All seeds fixed.
+    """
+
+    # Common DGP
+    G = 30
+    M = 10
+    SIGMA_U = 1.0
+    SIGMA_E = 0.5
+    MU_TRUE = 0.0
+    N_BOOT = 199
+    ALPHA = 0.05
+
+    @staticmethod
+    def _is_in_cr(
+        result: Any,
+        boot: Any,
+        sigma: np.ndarray,
+        point: Any,
+        alpha: float,
+    ) -> bool:
+        """CR membership using an explicit cluster-robust ``Sigma``.
+
+        Mirrors :meth:`MomentWildBootstrap.in_confidence_region` but pins
+        the covariance matrix on both sides of the inequality so the
+        cluster-vs-iid contrast isolates the bootstrap weight scheme.
+        """
+
+        d2_boots = boot.geodesic_distances(covariance=sigma)
+        cv = float(np.quantile(d2_boots, 1.0 - alpha))
+        d2_point = geodesic_mahalanobis_distance(
+            result, point, covariance=sigma
+        )
+        return d2_point <= cv
+
+    @pytest.mark.slow
+    def test_cluster_bootstrap_size(self) -> None:
+        """Empirical coverage of the cluster wild bootstrap CR is near 1 - alpha."""
+
+        n_reps = 100
+        rng = np.random.default_rng(2026)
+        contained = 0
+
+        for rep in range(n_reps):
+            data, cids = _draw_clustered_panel(
+                rng,
+                mu=self.MU_TRUE,
+                G=self.G,
+                m=self.M,
+                sigma_u=self.SIGMA_U,
+                sigma_e=self.SIGMA_E,
+            )
+            result, boot, sigma = _fit_and_bootstrap(
+                data,
+                cids,
+                n_bootstrap=self.N_BOOT,
+                base_seed=rep,
+                use_clusters_in_bootstrap=True,
+            )
+            if self._is_in_cr(
+                result, boot, sigma, jnp.array([self.MU_TRUE]), self.ALPHA
+            ):
+                contained += 1
+
+        coverage = contained / n_reps
+        # Nominal 0.95; with 100 reps SE ~= sqrt(0.95*0.05/100) ~= 0.022.
+        # Wide band absorbs MC noise and any small bootstrap finite-sample bias.
+        assert 0.88 <= coverage <= 1.0, (
+            f"cluster wild bootstrap coverage {coverage:.3f} "
+            f"outside [0.88, 1.0] band (nominal 0.95)"
+        )
+
+    @pytest.mark.slow
+    def test_cluster_bootstrap_power(self) -> None:
+        """Against an alternative the bootstrap CR rejects with sufficient power."""
+
+        n_reps = 30
+        # Pick mu_alt at roughly 3 cluster-SDs from 0; expected SD of theta_hat
+        # is sqrt((sigma_u^2 + sigma_e^2/m)/G) = sqrt((1 + 0.025)/30) ~= 0.185.
+        # mu_alt = 0.6 -> z ~= 3.2 -> theoretical power ~= 0.95.
+        mu_alt = 0.6
+        rng = np.random.default_rng(7)
+        rejected = 0
+
+        for rep in range(n_reps):
+            data, cids = _draw_clustered_panel(
+                rng,
+                mu=mu_alt,
+                G=self.G,
+                m=self.M,
+                sigma_u=self.SIGMA_U,
+                sigma_e=self.SIGMA_E,
+            )
+            result, boot, sigma = _fit_and_bootstrap(
+                data,
+                cids,
+                n_bootstrap=self.N_BOOT,
+                base_seed=1000 + rep,
+                use_clusters_in_bootstrap=True,
+            )
+            # H0: mu = 0 (we know the truth is mu = mu_alt)
+            in_cr = self._is_in_cr(
+                result, boot, sigma, jnp.array([self.MU_TRUE]), self.ALPHA
+            )
+            if not in_cr:
+                rejected += 1
+
+        power = rejected / n_reps
+        # Theoretical power ~= 0.95; with 30 reps the worst case (true power
+        # 0.8) has SE ~= 0.073.  Floor of 0.7 is comfortably above noise.
+        assert power >= 0.7, f"cluster bootstrap power {power:.3f} below 0.7"
+
+    @pytest.mark.slow
+    def test_iid_bootstrap_under_covers_clustered_dgp(self) -> None:
+        """Pre-fix bug regression check: per-obs wild bootstrap under-covers.
+
+        Uses the cluster-robust ``Sigma`` (same as the size test) so the
+        contrast against ``test_cluster_bootstrap_size`` isolates the
+        bootstrap weight scheme.  Confirms that per-observation wild
+        draws produce a bootstrap distribution too narrow for clustered
+        data, dropping coverage well below the nominal 0.95.  This is
+        the on-disk documentation of the bug this PR fixes.
+        """
+
+        n_reps = 100
+        rng = np.random.default_rng(2026)  # same seed as the size test
+        contained = 0
+
+        for rep in range(n_reps):
+            data, cids = _draw_clustered_panel(
+                rng,
+                mu=self.MU_TRUE,
+                G=self.G,
+                m=self.M,
+                sigma_u=self.SIGMA_U,
+                sigma_e=self.SIGMA_E,
+            )
+            result, boot, sigma = _fit_and_bootstrap(
+                data,
+                cids,
+                n_bootstrap=self.N_BOOT,
+                base_seed=rep,
+                use_clusters_in_bootstrap=False,
+            )
+            if self._is_in_cr(
+                result, boot, sigma, jnp.array([self.MU_TRUE]), self.ALPHA
+            ):
+                contained += 1
+
+        coverage = contained / n_reps
+        # With Sigma held fixed at the cluster-robust value and the
+        # bootstrap drawing i.i.d. weights, the bootstrap critical value
+        # is roughly the chi^2_1 quantile rescaled by (s_iid_boot / s_cluster)^2.
+        # For this DGP that ratio is ~ 1/2.6, so the effective alpha is
+        # ~ 2 * (1 - Phi(1.96/2.6)) ~= 0.45; coverage ~= 0.55.  Threshold
+        # at 0.85 leaves wide MC margin.
+        assert coverage < 0.85, (
+            f"per-obs wild bootstrap coverage {coverage:.3f} "
+            f"unexpectedly close to nominal 0.95; either the DGP is too "
+            f"weak or the bootstrap is not actually using i.i.d. draws"
+        )

--- a/tests/econometrics/test_bootstrap.py
+++ b/tests/econometrics/test_bootstrap.py
@@ -798,16 +798,26 @@ class TestClusterMonteCarlo:
     Parameters chosen so that the i.i.d. wild bootstrap is severely
     under-sized (intra-cluster correlation rho ~= 0.8) and the cluster
     bootstrap recovers correct coverage.  All seeds fixed.
+
+    Compute budget: with the rep counts below (~10,000 GMM fits total
+    across the three tests) and Euclidean(1) data of size
+    ``N = G*M = 100``, the suite runs in well under one hour
+    single-threaded.  Coverage SE at 50 outer reps is ~0.07 so the
+    assertion bands are intentionally wide; the cluster-vs-iid contrast
+    is huge (true coverage ~0.95 vs ~0.55) and easily resolved.
     """
 
-    # Common DGP
-    G = 30
-    M = 10
+    # Common DGP -- intentionally small to keep the slow-test budget
+    # bounded while preserving a clear cluster-vs-iid signal.
+    G = 20
+    M = 5
     SIGMA_U = 1.0
     SIGMA_E = 0.5
     MU_TRUE = 0.0
-    N_BOOT = 199
+    N_BOOT = 99
     ALPHA = 0.05
+    N_OUTER_SIZE = 50
+    N_OUTER_POWER = 20
 
     @staticmethod
     def _is_in_cr(
@@ -835,7 +845,7 @@ class TestClusterMonteCarlo:
     def test_cluster_bootstrap_size(self) -> None:
         """Empirical coverage of the cluster wild bootstrap CR is near 1 - alpha."""
 
-        n_reps = 100
+        n_reps = self.N_OUTER_SIZE
         rng = np.random.default_rng(2026)
         contained = 0
 
@@ -861,22 +871,22 @@ class TestClusterMonteCarlo:
                 contained += 1
 
         coverage = contained / n_reps
-        # Nominal 0.95; with 100 reps SE ~= sqrt(0.95*0.05/100) ~= 0.022.
+        # Nominal 0.95; with 50 reps SE ~= sqrt(0.95*0.05/50) ~= 0.031.
         # Wide band absorbs MC noise and any small bootstrap finite-sample bias.
-        assert 0.88 <= coverage <= 1.0, (
+        assert 0.85 <= coverage <= 1.0, (
             f"cluster wild bootstrap coverage {coverage:.3f} "
-            f"outside [0.88, 1.0] band (nominal 0.95)"
+            f"outside [0.85, 1.0] band (nominal 0.95)"
         )
 
     @pytest.mark.slow
     def test_cluster_bootstrap_power(self) -> None:
         """Against an alternative the bootstrap CR rejects with sufficient power."""
 
-        n_reps = 30
-        # Pick mu_alt at roughly 3 cluster-SDs from 0; expected SD of theta_hat
-        # is sqrt((sigma_u^2 + sigma_e^2/m)/G) = sqrt((1 + 0.025)/30) ~= 0.185.
-        # mu_alt = 0.6 -> z ~= 3.2 -> theoretical power ~= 0.95.
-        mu_alt = 0.6
+        n_reps = self.N_OUTER_POWER
+        # Pick mu_alt at roughly 3 cluster-SDs from 0; SD of theta_hat is
+        # sqrt((sigma_u^2 + sigma_e^2/m)/G) = sqrt((1 + 0.05)/20) ~= 0.229.
+        # mu_alt = 0.7 -> z ~= 3.06 -> theoretical power ~= 0.93.
+        mu_alt = 0.7
         rng = np.random.default_rng(7)
         rejected = 0
 
@@ -920,7 +930,7 @@ class TestClusterMonteCarlo:
         the on-disk documentation of the bug this PR fixes.
         """
 
-        n_reps = 100
+        n_reps = self.N_OUTER_SIZE
         rng = np.random.default_rng(2026)  # same seed as the size test
         contained = 0
 

--- a/tests/econometrics/test_bootstrap.py
+++ b/tests/econometrics/test_bootstrap.py
@@ -419,8 +419,7 @@ class TestClusterStructural:
         boot.run_sequential()
 
         assert captured == [3, 3], (
-            "scheme should be called with G=3 once per replicate, "
-            f"got {captured}"
+            "scheme should be called with G=3 once per replicate, " f"got {captured}"
         )
 
     def test_weights_constant_within_cluster(
@@ -440,9 +439,7 @@ class TestClusterStructural:
             captured_weights.append(np.asarray(w).copy())
             return original_with_weights(self, w)
 
-        monkeypatch.setattr(
-            mr_mod.MomentRestriction, "with_weights", spy_with_weights
-        )
+        monkeypatch.setattr(mr_mod.MomentRestriction, "with_weights", spy_with_weights)
 
         boot = MomentWildBootstrap(
             result, n_bootstrap=2, clusters=cluster_ids, base_seed=0
@@ -456,8 +453,7 @@ class TestClusterStructural:
                 mask = cluster_ids == c
                 unique_vals = np.unique(w[mask])
                 assert unique_vals.size == 1, (
-                    f"weights not cluster-constant for cluster {c}: "
-                    f"{w[mask]}"
+                    f"weights not cluster-constant for cluster {c}: " f"{w[mask]}"
                 )
 
     def test_auto_default_from_restriction_clusters(self) -> None:
@@ -556,14 +552,20 @@ class TestClusterStructural:
         # Round trip
         data = task.to_bytes()
         revived = BootstrapTask.from_bytes(data)
-        assert callable(revived.weight_scheme)
+        # Narrow weight_scheme from str | Callable to Callable so mypy is
+        # happy with the call-syntax below and the runtime assertion
+        # doubles as the structural check.
+        scheme_task = task.weight_scheme
+        scheme_revived = revived.weight_scheme
+        assert callable(scheme_task)
+        assert callable(scheme_revived)
         # Same RNG state should yield identical weights
         n_clusters = revived.num_clusters
         assert n_clusters is not None
         rng1 = np.random.default_rng(123)
         rng2 = np.random.default_rng(123)
-        w1 = task.weight_scheme(n_clusters, rng1)  # type: ignore[operator]
-        w2 = revived.weight_scheme(n_clusters, rng2)  # type: ignore[operator]
+        w1 = scheme_task(n_clusters, rng1)
+        w2 = scheme_revived(n_clusters, rng2)
         np.testing.assert_array_equal(w1, w2)
 
         # End-to-end run also succeeds via the revived task
@@ -767,14 +769,10 @@ def _fit_and_bootstrap(
     )
     gmm = GMM(restriction, initial_point=jnp.array([0.0]))
     result = gmm.estimate()
-    sigma_cluster = np.asarray(
-        result.tangent_covariance().to_numpy(dtype=float)
-    )
+    sigma_cluster = np.asarray(result.tangent_covariance().to_numpy(dtype=float))
 
     if use_clusters_in_bootstrap:
-        boot = MomentWildBootstrap(
-            result, n_bootstrap=n_bootstrap, base_seed=base_seed
-        )
+        boot = MomentWildBootstrap(result, n_bootstrap=n_bootstrap, base_seed=base_seed)
     else:
         # Build a parallel result whose restriction lacks clusters so the
         # bootstrap's auto-default falls back to per-observation draws.
@@ -782,7 +780,7 @@ def _fit_and_bootstrap(
         # ``sigma_cluster`` explicitly to keep the contrast clean.
         from dataclasses import replace as dc_replace
 
-        bare_restriction = restriction.with_clusters(None)  # type: ignore[arg-type]
+        bare_restriction = restriction.with_clusters(None)
         bare_result = dc_replace(result, restriction=bare_restriction)
         boot = MomentWildBootstrap(
             bare_result, n_bootstrap=n_bootstrap, base_seed=base_seed
@@ -836,9 +834,7 @@ class TestClusterMonteCarlo:
 
         d2_boots = boot.geodesic_distances(covariance=sigma)
         cv = float(np.quantile(d2_boots, 1.0 - alpha))
-        d2_point = geodesic_mahalanobis_distance(
-            result, point, covariance=sigma
-        )
+        d2_point = geodesic_mahalanobis_distance(result, point, covariance=sigma)
         return d2_point <= cv
 
     @pytest.mark.slow


### PR DESCRIPTION
## Summary

Three correctness fixes to `MomentWildBootstrap`, addressing the loky-fork hazard and cluster-blindness flagged in #7:

- **Per-cluster wild draws.** `MomentWildBootstrap` accepts `clusters=` (auto-defaulted from `restriction.clusters`) and draws one wild weight per unique cluster, broadcast to member rows. With clusters of size 1 the path is byte-identical to the pre-fix behaviour.
- **Callable `weight_scheme=`.** Accepts `str | Callable` and removes the module-level `_WEIGHT_GENERATORS` lookup as a worker-side dependency. Custom schemes ride through the pickled `BootstrapTask` payload, so parent-process registrations no longer have to survive a fork to a loky worker.
- **Cluster inheritance in replicate restrictions.** `BootstrapTask.run` chains `with_clusters(...)` after `with_weights(...)` when the parent restriction carries clusters, so replicate `Ω̂` is cluster-robust ("the composition linchpin").

Mirrors the API shape of PR #5 (`clusters=` kwarg + `with_clusters` immutable clone, default reproduces today's behaviour bit-for-bit). Docstrings cover the three caveats from the issue: finite-cluster correction (effective sample size is `G`), the singleton-clusters identity, and the callable-pickling requirement.

## Test plan

Structural and API (`tests/econometrics/test_bootstrap.py`, non-slow):
- [x] Singleton clusters (`G = N`) byte-identical to i.i.d. path
- [x] Per-cluster constancy of weights via `monkeypatch` spy on `with_weights`
- [x] Callable scheme called with `G`, not `N`, when clustered
- [x] Auto-default from `restriction.clusters`; explicit `clusters=` overrides
- [x] Replicate restriction carries `.clusters` when clustered
- [x] Callable `weight_scheme=` survives `to_bytes` / `from_bytes` round-trip and runs end-to-end
- [x] User-defined callable bypasses `_WEIGHT_GENERATORS` entirely
- [x] Validation: bad scheme type, bad `clusters=` shape, non-1-D `clusters=`

Statistical (`@pytest.mark.slow`):
- [x] **Size**: empirical coverage of cluster wild bootstrap CR on a clustered DGP (G=20, m=5, ρ≈0.8) is within [0.85, 1.0] at nominal 0.95
- [x] **Power**: against `mu_alt = 0.7` (~3 cluster-SDs from H0), rejection rate ≥ 0.7
- [x] **i.i.d. under-covers same DGP**: with the cluster-robust Σ pinned on both sides, per-observation wild bootstrap coverage drops below 0.85 — on-disk regression check of the pre-fix bug

Validation:
- [x] `make check` (ruff, black, mypy, full pytest incl. slow) green on a Slurm dispatch (`co_carleton`, `savio2_htc`)

Closes #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
