### PR TITLE
Fix _run_stage to read real OptimizerResult fields (#10 part 1)

### DIFF
--- a/src/manifoldgmm/econometrics/gmm.py
+++ b/src/manifoldgmm/econometrics/gmm.py
@@ -1117,6 +1117,28 @@ class GMM:
             return CallableWeighting(weighting)
         return FixedWeighting(weighting)
 
+    # Kwargs that belong on TrustRegions.run() rather than __init__().
+    # (pymanopt's TrustRegions.run accepts mininner, maxinner, Delta_bar,
+    # Delta0; __init__ takes miniter, kappa, theta, rho_prime, use_rand,
+    # rho_regularization, plus base Optimizer kwargs.)
+    _OPTIMIZER_RUN_KWARGS = frozenset(
+        {"mininner", "maxinner", "Delta_bar", "Delta0"}
+    )
+
+    @classmethod
+    def _split_optimizer_kwargs(
+        cls, optimizer_kwargs: Mapping[str, Any]
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Partition optimizer_kwargs into (init_kwargs, run_kwargs)."""
+        init_kwargs: dict[str, Any] = {}
+        run_kwargs: dict[str, Any] = {}
+        for key, value in optimizer_kwargs.items():
+            if key in cls._OPTIMIZER_RUN_KWARGS:
+                run_kwargs[key] = value
+            else:
+                init_kwargs[key] = value
+        return init_kwargs, run_kwargs
+
     def _resolve_optimizer(self, optimizer_kwargs: Mapping[str, Any]) -> Optimizer:
         base = self._optimizer
         if base is None:
@@ -1146,13 +1168,16 @@ class GMM:
         if manifold_wrapper is None or manifold_wrapper.data is None:
             raise ValueError("MomentRestriction must define a manifold to run GMM.")
         problem = Problem(cost=cost, manifold=manifold_wrapper.data)
-        optimizer = self._resolve_optimizer(optimizer_kwargs)
+        init_kwargs, run_kwargs = self._split_optimizer_kwargs(
+            dict(optimizer_kwargs)
+        )
+        optimizer = self._resolve_optimizer(init_kwargs)
         start_value = (
             initial_point.value
             if isinstance(initial_point, ManifoldPoint)
             else initial_point
         )
-        result = optimizer.run(problem, initial_point=start_value)
+        result = optimizer.run(problem, initial_point=start_value, **run_kwargs)
         theta_value = result.point
         theta_point = ManifoldPoint(
             manifold_wrapper,

--- a/src/manifoldgmm/econometrics/gmm.py
+++ b/src/manifoldgmm/econometrics/gmm.py
@@ -229,6 +229,45 @@ class IdentityWeighting(FixedWeighting):
         super().__init__(np.eye(dimension, dtype=float), label="identity")
 
 
+def _classify_converged(stopping_criterion: str | None) -> bool | None:
+    """Heuristic boolean convergence flag from a pymanopt stopping string.
+
+    Pymanopt's :class:`~pymanopt.optimizers.optimizer.OptimizerResult`
+    exposes ``stopping_criterion`` as a free-form message rather than a
+    structured enum.  This helper maps the standard messages produced by
+    :meth:`Optimizer._check_stopping_criterion` to a boolean:
+
+    - ``True`` when a tolerance was reached (``"min grad norm"`` or
+      ``"min step_size"``) -- the optimizer is reporting the iterate
+      satisfies a stationary-point criterion.
+    - ``False`` when a resource budget was exhausted
+      (``"max iterations"``, ``"max time"``, ``"max cost evals"``) --
+      the iterate did *not* satisfy any tolerance.
+    - ``None`` when the criterion string is missing or unrecognised, so
+      downstream code that needs to distinguish "didn't converge" from
+      "no information" can do so.  ``bool(None)`` is ``False``, so
+      legacy callers that fall back to ``False`` on ``None`` keep their
+      conservative behaviour.
+    """
+
+    if not stopping_criterion:
+        return None
+    lowered = stopping_criterion.lower()
+    if (
+        "min grad norm" in lowered
+        or "min step_size" in lowered
+        or "min step size" in lowered
+    ):
+        return True
+    if (
+        "max iterations" in lowered
+        or "max time" in lowered
+        or "max cost evals" in lowered
+    ):
+        return False
+    return None
+
+
 @dataclass
 class WaldTestResult:
     """Result of a Wald test for H0: h(theta) = 0.
@@ -1121,9 +1160,7 @@ class GMM:
     # (pymanopt's TrustRegions.run accepts mininner, maxinner, Delta_bar,
     # Delta0; __init__ takes miniter, kappa, theta, rho_prime, use_rand,
     # rho_regularization, plus base Optimizer kwargs.)
-    _OPTIMIZER_RUN_KWARGS = frozenset(
-        {"mininner", "maxinner", "Delta_bar", "Delta0"}
-    )
+    _OPTIMIZER_RUN_KWARGS = frozenset({"mininner", "maxinner", "Delta_bar", "Delta0"})
 
     @classmethod
     def _split_optimizer_kwargs(
@@ -1168,9 +1205,7 @@ class GMM:
         if manifold_wrapper is None or manifold_wrapper.data is None:
             raise ValueError("MomentRestriction must define a manifold to run GMM.")
         problem = Problem(cost=cost, manifold=manifold_wrapper.data)
-        init_kwargs, run_kwargs = self._split_optimizer_kwargs(
-            dict(optimizer_kwargs)
-        )
+        init_kwargs, run_kwargs = self._split_optimizer_kwargs(dict(optimizer_kwargs))
         optimizer = self._resolve_optimizer(init_kwargs)
         start_value = (
             initial_point.value
@@ -1184,10 +1219,29 @@ class GMM:
             theta_value,
         )
         g_bar_hat = self._restriction.g_bar(theta_point)
+        # Surface the fields pymanopt's ``OptimizerResult`` actually
+        # exposes (see ``pymanopt.optimizers.optimizer.OptimizerResult``).
+        # The previous report read ``converged`` and ``stopping_reason``
+        # via ``getattr`` with a ``None`` fallback; pymanopt defines
+        # neither attribute, so both came back silently ``None`` for every
+        # fit -- which in turn made ``BootstrapResult.converged`` always
+        # ``False`` (bootstrap.py line 328 falls back to ``False`` when
+        # the key is None).  ``converged`` is now synthesised from the
+        # stopping-criterion string so downstream consumers get a real
+        # signal.  ``stopping_criterion`` is the canonical key going
+        # forward; we keep the field set tolerant via ``getattr`` so
+        # third-party optimizers that omit individual fields still work.
+        stopping_criterion = getattr(result, "stopping_criterion", None)
         optimizer_report = {
             "iterations": getattr(result, "iterations", None),
-            "converged": getattr(result, "converged", None),
-            "stopping_reason": getattr(result, "stopping_reason", None),
+            "stopping_criterion": stopping_criterion,
+            "converged": _classify_converged(stopping_criterion),
+            "cost": getattr(result, "cost", None),
+            "gradient_norm": getattr(result, "gradient_norm", None),
+            "step_size": getattr(result, "step_size", None),
+            "cost_evaluations": getattr(result, "cost_evaluations", None),
+            "time": getattr(result, "time", None),
+            "log": getattr(result, "log", None),
         }
         return _StageResult(
             theta=theta_point,

--- a/tests/econometrics/test_gmm.py
+++ b/tests/econometrics/test_gmm.py
@@ -444,6 +444,136 @@ def test_moment_restriction_pickle_round_trip() -> None:
 
 
 # -----------------------------------------------------------------------
+# optimizer_report attribute surface (#10 part 1)
+# -----------------------------------------------------------------------
+
+
+def test_optimizer_report_surfaces_pymanopt_fields() -> None:
+    """A real fit populates the actual pymanopt OptimizerResult fields.
+
+    Prior to the part-1 fix on #10, ``_run_stage`` read ``converged`` and
+    ``stopping_reason`` via ``getattr`` with a ``None`` fallback.
+    Pymanopt's ``OptimizerResult`` defines neither attribute, so both
+    fields came back silently ``None`` for every fit -- in particular
+    flipping ``BootstrapResult.converged`` permanently to ``False`` (it
+    bool-casts the report value).  This test pins the corrected surface.
+    """
+
+    restriction, _ = _build_simple_restriction()
+    gmm = GMM(restriction, initial_point=jnp.array([0.0]))
+    result = gmm.estimate()
+
+    report = result.optimizer_report
+
+    # Canonical key from pymanopt.
+    assert "stopping_criterion" in report
+    sc = report["stopping_criterion"]
+    assert isinstance(sc, str) and sc, "stopping_criterion should be a non-empty string"
+    assert "Terminated" in sc, f"unexpected stopping_criterion: {sc!r}"
+
+    # Synthesised convergence flag: this trivial mean-estimation problem
+    # converges to the optimum (min grad norm reached), so the flag must
+    # be True -- not None and not False.
+    assert report["converged"] is True, (
+        f"converged should be True for a trivial fit; got {report['converged']!r} "
+        f"with stopping_criterion={sc!r}"
+    )
+
+    # Pulled-through pymanopt fields all present and sensible.  We're
+    # deliberately permissive about the concrete numeric type -- the
+    # JAX backend returns ``jax.Array`` for cost and gradient norm
+    # while the numpy path returns Python scalars; both are valid.
+    assert isinstance(report["iterations"], int) and report["iterations"] >= 0
+    assert report["cost"] is not None
+    assert np.isfinite(float(report["cost"]))
+    assert report["gradient_norm"] is not None
+    assert float(report["gradient_norm"]) >= 0.0
+    assert "time" in report and float(report["time"]) >= 0.0
+    # log is optional (only populated at log_verbosity>=1); just check it
+    # exists as a key.
+    assert "log" in report
+
+    # The legacy ``stopping_reason`` key is gone -- callers should
+    # migrate to ``stopping_criterion``.  Make this explicit so a future
+    # accidental reintroduction is caught.
+    assert "stopping_reason" not in report
+
+
+def test_classify_converged_recognises_pymanopt_strings() -> None:
+    """The convergence classifier maps the standard pymanopt strings."""
+
+    from manifoldgmm.econometrics.gmm import _classify_converged
+
+    # Tolerance-style stops -> converged
+    assert (
+        _classify_converged(
+            "Terminated - min grad norm reached after 9 iterations, 1.50 seconds."
+        )
+        is True
+    )
+    assert (
+        _classify_converged(
+            "Terminated - min step_size reached after 12 iterations, 0.30 seconds."
+        )
+        is True
+    )
+
+    # Budget-style stops -> not converged
+    assert (
+        _classify_converged("Terminated - max iterations reached after 60.00 seconds.")
+        is False
+    )
+    assert (
+        _classify_converged("Terminated - max time reached after 200 iterations.")
+        is False
+    )
+    assert (
+        _classify_converged("Terminated - max cost evals reached after 5.00 seconds.")
+        is False
+    )
+
+    # Missing or unrecognised -> None (don't pretend to know)
+    assert _classify_converged(None) is None
+    assert _classify_converged("") is None
+    assert _classify_converged("some custom optimizer message") is None
+
+
+def test_bootstrap_converged_no_longer_permanently_false() -> None:
+    """Bootstrap replicates now inherit a real converged flag.
+
+    Pre-fix, ``optimizer_report['converged']`` was always ``None`` so
+    ``BootstrapResult.converged`` was always ``False`` (the bootstrap
+    bool-casts the report value).  Post-fix, a successful Euclidean(1)
+    replicate fit should report ``converged=True``.
+    """
+
+    from manifoldgmm.econometrics.bootstrap import BootstrapTask
+
+    restriction, _ = _build_simple_restriction()
+    gmm = GMM(restriction, initial_point=jnp.array([0.0]))
+    result = gmm.estimate()
+
+    weighting: Any = result.weighting
+    assert weighting is not None
+    W = np.asarray(weighting.matrix(result.theta)).astype(float)
+    task = BootstrapTask(
+        restriction=restriction,
+        weighting_matrix=W,
+        initial_point=result.theta_array,
+        seed=0,
+        weight_scheme="rademacher",
+        optimizer_class=None,
+        optimizer_kwargs={},
+        task_id=0,
+    )
+    br = task.run()
+    assert br.converged is True, (
+        f"Bootstrap replicate should report converged=True for a trivial "
+        f"Euclidean(1) fit; got {br.converged!r}"
+    )
+
+
+# -----------------------------------------------------------------------
 # Canonical-Jacobian cache (#4)
 # -----------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

`_run_stage` in `gmm.py` was building `optimizer_report` from attributes that pymanopt's `OptimizerResult` does not define:

\`\`\`python
\"converged\":      getattr(result, \"converged\", None),
\"stopping_reason\":getattr(result, \"stopping_reason\", None),
\`\`\`

Both came back silently \`None\` for every fit. The real field is \`stopping_criterion\`; there is no boolean \`converged\` on \`OptimizerResult\`.

**Downstream fallout the latent bug was masking.** \`bootstrap.py:328\` reads \`result.optimizer_report.get(\"converged\", False)\` to set \`BootstrapResult.converged\`. With the report value always \`None\`, every bootstrap replicate has been reporting \`converged=False\` regardless of the actual optimization outcome, and \`MomentWildBootstrap.summary()[\"n_converged\"]\` has been permanently 0.

## Fix

- Rename the report key to \`stopping_criterion\` (matches pymanopt's field name).
- Synthesise \`converged\` from the criterion string via a small classifier (\`_classify_converged\`) that returns \`True\` for tolerance-style stops (min grad norm / min step size), \`False\` for budget-exhausted stops (max iterations / time / cost evals), and \`None\` when the string is missing or unrecognised. \`bool(None)\` is \`False\`, so legacy callers that fall back to \`False\` on \`None\` keep their conservative behaviour.
- Pull through the additional \`OptimizerResult\` fields (\`cost\`, \`gradient_norm\`, \`step_size\`, \`cost_evaluations\`, \`time\`, \`log\`) so the parts-2-and-3 follow-ups on #10 don't have to revisit \`_run_stage\`.

## Test plan

- [x] \`test_optimizer_report_surfaces_pymanopt_fields\`: real fit on Euclidean(1) populates \`stopping_criterion\` (non-empty, contains \"Terminated\"), sets \`converged=True\`, and the pulled-through fields are present and numerically sensible. Also asserts the legacy \`stopping_reason\` key is gone so an accidental reintroduction is caught.
- [x] \`test_classify_converged_recognises_pymanopt_strings\`: unit-tests the helper against the five \`_check_stopping_criterion\` messages pymanopt emits, plus \`None\` / empty / unrecognised.
- [x] \`test_bootstrap_converged_no_longer_permanently_false\`: end-to-end check that a bootstrap replicate inherits the corrected flag (was always \`False\`, should be \`True\` on this trivial Euclidean(1) fit).
- [x] Local \`make check\`-equivalent (ruff / black / mypy / non-slow pytest) green. Slow MC tests left to GitHub Actions.

## Scope

This is **part 1 of #10**. Parts 2 (vendored inner-CG-logging trust-region subclass) and 3 (\`GMMResult.optimizer_health\` with \`inner_cap_hit_frac\`, \`tail_grad_slope\`, \`hessian_cond_at_theta\`) follow in separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)