### PR TITLE
Add LoggingTrustRegions + GMMResult.optimizer_health (#10 PR 1, cont.)

### DIFF
--- a/src/manifoldgmm/__init__.py
+++ b/src/manifoldgmm/__init__.py
@@ -15,8 +15,10 @@ except PackageNotFoundError:
 from .autodiff import jacobian_from_pymanopt, jacobian_operator
 from .econometrics import GMM, GMMResult, KStatisticResult, MomentRestriction
 from .econometrics.bootstrap import MomentWildBootstrap, geodesic_mahalanobis_distance
+from .econometrics.gmm import OptimizerHealth
 from .econometrics.simulation import monte_carlo
 from .geometry import Manifold, ManifoldPoint
+from .optimizers import LoggingTrustRegions
 
 __all__ = [
     "jacobian_operator",
@@ -30,4 +32,6 @@ __all__ = [
     "MomentWildBootstrap",
     "geodesic_mahalanobis_distance",
     "monte_carlo",
+    "LoggingTrustRegions",
+    "OptimizerHealth",
 ]

--- a/src/manifoldgmm/econometrics/gmm.py
+++ b/src/manifoldgmm/econometrics/gmm.py
@@ -20,10 +20,10 @@ except ImportError:  # pragma: no cover - optional
 from pymanopt import Problem
 from pymanopt.function import jax as pymanopt_jax_function
 from pymanopt.function import numpy as pymanopt_numpy_function
-from pymanopt.optimizers import TrustRegions
 from pymanopt.optimizers.optimizer import Optimizer
 
 from ..geometry import Manifold, ManifoldPoint
+from ..optimizers import LoggingTrustRegions
 from .moment_restriction import MomentRestriction
 
 
@@ -312,6 +312,49 @@ class KStatisticResult:
 
 
 @dataclass
+class OptimizerHealth:
+    """Cheap diagnostics derived from the optimizer's per-iteration log.
+
+    Returned by :meth:`GMMResult.optimizer_health`.  All fields are
+    optional; they are populated only when the optimizer wrote the
+    relevant per-iteration data into ``OptimizerResult.log`` (which
+    requires ``log_verbosity >= 1`` and -- for ``inner_cap_hit_frac``
+    specifically -- a logging-aware TrustRegions subclass such as
+    :class:`~manifoldgmm.optimizers.LoggingTrustRegions`).
+
+    A ``None`` field means "the log did not carry the data needed to
+    compute this metric"; downstream callers should treat that as
+    "no information" rather than as a value.
+
+    Attributes
+    ----------
+    n_iterations:
+        Number of per-iteration entries in the log (the outer iteration
+        count actually persisted).
+    inner_cap_hit_frac:
+        Fraction of outer iterations whose inner truncated-CG terminated
+        because ``MAX_INNER_ITER`` was reached, i.e. the cap fired.
+        Heuristically: a value > 0.5 paired with an outer ``max iterations``
+        stop and a flat tail of ``log|grad|`` is the stuck-optimizer
+        pathology issue #10 was opened against.  ``None`` when
+        ``inner_stop_code`` is absent from the log.
+    tail_grad_slope:
+        Least-squares slope of ``log gradient_norm`` over the last
+        ``tail_window`` iterations.  Near zero indicates the outer loop
+        has stalled (gradient norm no longer decreasing).  ``None`` when
+        ``gradient_norm`` is absent from the log or fewer than two
+        non-positive-finite gradient values are available in the tail.
+    tail_window:
+        Number of iterations used for ``tail_grad_slope``.
+    """
+
+    n_iterations: int | None = None
+    inner_cap_hit_frac: float | None = None
+    tail_grad_slope: float | None = None
+    tail_window: int | None = None
+
+
+@dataclass
 class GMMResult:
     """Container returned by :meth:`GMM.estimate`."""
 
@@ -566,6 +609,93 @@ class GMMResult:
 
         return self.manifold_covariance(
             weighting=weighting, ridge_condition=ridge_condition, basis=basis
+        )
+
+    def optimizer_health(self, *, tail_window: int = 10) -> OptimizerHealth:
+        """Cheap stuck-optimizer diagnostics from the per-iteration log.
+
+        Reads ``optimizer_report["log"]["iterations"]`` (populated when the
+        optimizer ran at ``log_verbosity >= 1``) and computes:
+
+        - :attr:`OptimizerHealth.inner_cap_hit_frac` from the per-iteration
+          ``inner_stop_code`` series (requires a logging-aware TrustRegions
+          subclass such as
+          :class:`~manifoldgmm.optimizers.LoggingTrustRegions`, the package
+          default for :class:`GMM`).
+        - :attr:`OptimizerHealth.tail_grad_slope` from the per-iteration
+          ``gradient_norm`` series.
+
+        Any field for which the underlying log series is missing or too
+        short to compute is returned as ``None``.
+
+        Parameters
+        ----------
+        tail_window:
+            Number of trailing iterations used to compute the LS slope of
+            ``log gradient_norm``.  Clamped to the available log length.
+
+        Returns
+        -------
+        OptimizerHealth
+            Dataclass with optional float fields; see
+            :class:`OptimizerHealth` for the per-field semantics.
+        """
+
+        log = (self.optimizer_report or {}).get("log") or {}
+        iterations = log.get("iterations") if isinstance(log, Mapping) else None
+        if not isinstance(iterations, Mapping):
+            return OptimizerHealth()
+
+        n_iter_list = iterations.get("iteration")
+        n_iterations = len(n_iter_list) if n_iter_list is not None else None
+
+        # inner_cap_hit_frac: fraction of outer iterations where the inner
+        # truncated-CG ran to its maxinner cap.  We use ``num_inner ==
+        # maxinner`` rather than ``inner_stop_code == MAX_INNER_ITER``
+        # because pymanopt pre-assumes the latter and only overwrites on
+        # early termination, so the stop code false-positives when the
+        # inner loop body never ran (e.g. gradient already zero, num_inner
+        # == 0).  The strict ``num_inner == maxinner`` predicate matches
+        # the actual pathology issue #10 was opened against.
+        inner_cap_hit_frac: float | None = None
+        num_inner = iterations.get("num_inner")
+        maxinner = iterations.get("maxinner")
+        if num_inner and maxinner and len(num_inner) == len(maxinner):
+            paired = [
+                (n, m)
+                for n, m in zip(num_inner, maxinner, strict=False)
+                if n is not None and m is not None
+            ]
+            if paired:
+                cap_hits = sum(1 for n, m in paired if n >= m)
+                inner_cap_hit_frac = cap_hits / len(paired)
+
+        # tail_grad_slope: LS slope of log|grad| on the last `tail_window`
+        # iterations, ignoring non-positive / non-finite entries (which
+        # cannot be log-transformed).
+        tail_grad_slope: float | None = None
+        used_window: int | None = None
+        gnorms = iterations.get("gradient_norm")
+        if gnorms:
+            tail = np.asarray([g for g in gnorms if g is not None], dtype=float)
+            if tail.size:
+                window = int(min(max(tail_window, 2), tail.size))
+                tail = tail[-window:]
+                mask = np.isfinite(tail) & (tail > 0)
+                if int(mask.sum()) >= 2:
+                    used_window = window
+                    x = np.arange(tail.size, dtype=float)[mask]
+                    y = np.log(tail[mask])
+                    # np.polyfit(deg=1) is overkill but explicit; the LS
+                    # slope is x.cov(y) / x.var.
+                    slope, _ = np.polyfit(x, y, 1)
+                    tail_grad_slope = float(slope)
+
+        return OptimizerHealth(
+            n_iterations=n_iterations,
+            inner_cap_hit_frac=inner_cap_hit_frac,
+            tail_grad_slope=tail_grad_slope,
+            tail_window=used_window,
         )
 
     def as_dict(self) -> Mapping[str, Any]:
@@ -1179,7 +1309,12 @@ class GMM:
     def _resolve_optimizer(self, optimizer_kwargs: Mapping[str, Any]) -> Optimizer:
         base = self._optimizer
         if base is None:
-            return TrustRegions(**optimizer_kwargs)
+            # ``LoggingTrustRegions`` is a behaviour-preserving subclass of
+            # ``TrustRegions`` that additionally surfaces inner-CG state into
+            # ``OptimizerResult.log`` at ``log_verbosity >= 1``.  Used as the
+            # default so :meth:`GMMResult.optimizer_health` has the telemetry
+            # it needs without callers having to opt in.
+            return LoggingTrustRegions(**optimizer_kwargs)
         if isinstance(base, Optimizer):
             if optimizer_kwargs:
                 allowed = {"verbosity", "log_verbosity"}

--- a/src/manifoldgmm/optimizers/__init__.py
+++ b/src/manifoldgmm/optimizers/__init__.py
@@ -1,0 +1,14 @@
+"""Vendored / customised optimizer subclasses used by manifoldgmm.
+
+These exist to surface state pymanopt's stock optimizers know about but do
+not persist into :class:`~pymanopt.optimizers.optimizer.OptimizerResult`.
+Each subclass is a drop-in replacement for its upstream parent: same
+constructor signature, same ``run`` interface, additive behaviour only.
+
+See pymanopt/pymanopt#302 for the upstream patches that would let these
+subclasses be retired.
+"""
+
+from .logging_trust_regions import LoggingTrustRegions
+
+__all__ = ["LoggingTrustRegions"]

--- a/src/manifoldgmm/optimizers/logging_trust_regions.py
+++ b/src/manifoldgmm/optimizers/logging_trust_regions.py
@@ -1,0 +1,127 @@
+"""TrustRegions subclass that surfaces inner-CG state to the per-iteration log.
+
+Pymanopt's :class:`~pymanopt.optimizers.trust_regions.TrustRegions` prints
+the inner truncated-CG (tCG) stop reason at ``verbosity >= 2`` but never
+persists it via ``_add_log_entry``.  The result is that the well-known
+stuck-optimizer pathology -- outer iterations accept steps while every
+inner tCG hits ``MAX_INNER_ITER`` -- is invisible to programmatic
+diagnostics on :class:`~pymanopt.optimizers.optimizer.OptimizerResult`.
+
+This subclass overrides two hooks on the base optimizer:
+
+- :meth:`_truncated_conjugate_gradient`: stash ``(num_inner, stop_code)``
+  for the surrounding outer iteration to read.
+- :meth:`_check_stopping_criterion`: at the existing per-iteration call
+  site, log the stashed inner state alongside the outer gradient norm via
+  the existing ``_add_log_entry`` machinery.
+
+No method bodies are duplicated; the upstream control flow is unchanged.
+When ``log_verbosity == 0`` the overrides are no-ops -- pymanopt's
+``_add_log_entry`` short-circuits in that mode -- so the cost over plain
+``TrustRegions`` is two integer attribute assignments per outer iteration.
+
+See:
+
+- ManifoldGMM issue #10 for the surrounding observability proposal.
+- pymanopt/pymanopt#302 for the upstream patch that would let us retire
+  this subclass.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from pymanopt.optimizers import TrustRegions
+
+
+class LoggingTrustRegions(TrustRegions):
+    """Drop-in replacement for ``TrustRegions`` that logs inner-CG state.
+
+    At ``log_verbosity >= 1`` the per-iteration log
+    (``result.log["iterations"]``) gains four extra keys alongside the
+    base optimizer's ``time``/``iteration``/``point``/``cost`` lists:
+
+    ``num_inner``
+        The integer iteration count returned by the inner truncated-CG.
+    ``maxinner``
+        The cap on inner iterations in effect for this outer step
+        (constant across a run; logged per-row so the cap-hit predicate
+        ``num_inner == maxinner`` is self-contained).
+    ``inner_stop_code``
+        One of the integer stop-code constants defined on
+        :class:`TrustRegions`
+        (``NEGATIVE_CURVATURE``, ``EXCEEDED_TR``,
+        ``REACHED_TARGET_LINEAR``, ``REACHED_TARGET_SUPERLINEAR``,
+        ``MAX_INNER_ITER``, ``MODEL_INCREASED``).  Note: pymanopt
+        pre-assumes ``MAX_INNER_ITER`` and only overwrites on early
+        termination, so the stop code alone can false-positive when
+        ``num_inner == 0`` (gradient zero, inner loop body never ran);
+        use ``num_inner == maxinner`` for the cap-hit predicate.
+    ``gradient_norm``
+        The outer Riemannian gradient norm at this iteration.
+
+    ``point`` and ``cost`` are logged as ``None`` -- they live in scope
+    only inside the outer ``run`` loop, which we do not duplicate.  The
+    downstream metrics on :class:`~manifoldgmm.econometrics.gmm.GMMResult`
+    do not consume them.
+    """
+
+    def _truncated_conjugate_gradient(
+        self,
+        problem,
+        x,
+        fgradx,
+        eta,
+        Delta,
+        theta,
+        kappa,
+        mininner,
+        maxinner,
+    ):
+        eta, Heta, num_inner, stop_code = super()._truncated_conjugate_gradient(
+            problem, x, fgradx, eta, Delta, theta, kappa, mininner, maxinner
+        )
+        # Stashed for the immediately-following ``_check_stopping_criterion``
+        # call to read.  ``maxinner`` is constant across a run but we stash
+        # it alongside the per-iteration ``num_inner`` so the per-row record
+        # is self-contained (a consumer reading a single row of the log can
+        # decide cap-hit without joining against a separate scalar).
+        self._last_inner_num_inner = int(num_inner)
+        self._last_inner_stop_code = int(stop_code)
+        self._last_inner_maxinner = int(maxinner)
+        return eta, Heta, num_inner, stop_code
+
+    def _check_stopping_criterion(
+        self,
+        *,
+        start_time,
+        iteration: int = -1,
+        gradient_norm: float = np.inf,
+        step_size: float = np.inf,
+        cost_evaluations: int = -1,
+    ):
+        reason = super()._check_stopping_criterion(
+            start_time=start_time,
+            iteration=iteration,
+            gradient_norm=gradient_norm,
+            step_size=step_size,
+            cost_evaluations=cost_evaluations,
+        )
+        # Append a per-outer-iteration log entry with the inner-CG state.
+        # ``_add_log_entry`` short-circuits at ``log_verbosity < 1``, so
+        # the overhead in the common (non-logging) case is one attribute
+        # access and the call itself.
+        #
+        # ``iteration > 0`` skips the pre-loop call (before any inner CG
+        # has run).  ``self._log is not None`` is the standard guard used
+        # by the base class.
+        if iteration > 0 and self._log is not None:
+            self._add_log_entry(
+                iteration=iteration,
+                point=None,
+                cost=None,
+                gradient_norm=float(gradient_norm),
+                num_inner=getattr(self, "_last_inner_num_inner", None),
+                inner_stop_code=getattr(self, "_last_inner_stop_code", None),
+                maxinner=getattr(self, "_last_inner_maxinner", None),
+            )
+        return reason

--- a/tests/econometrics/test_gmm.py
+++ b/tests/econometrics/test_gmm.py
@@ -574,6 +574,182 @@ def test_bootstrap_converged_no_longer_permanently_false() -> None:
 
 
 # -----------------------------------------------------------------------
+# LoggingTrustRegions + optimizer_health (#10 PR 1, remaining)
+# -----------------------------------------------------------------------
+
+
+def test_default_optimizer_is_logging_trust_regions() -> None:
+    """``GMM.estimate`` should default to ``LoggingTrustRegions``.
+
+    PR #11 fixed the report fields; this remaining piece of #10 PR 1
+    wires the logging-aware optimizer in as the default so
+    ``GMMResult.optimizer_health`` has its telemetry without callers
+    having to opt in.
+    """
+
+    from manifoldgmm.optimizers import LoggingTrustRegions
+    from pymanopt.optimizers import TrustRegions
+
+    restriction, _ = _build_simple_restriction()
+    gmm = GMM(restriction, initial_point=jnp.array([0.0]))
+    # The default ``estimate`` call should resolve through
+    # ``LoggingTrustRegions``; ``optimizer_report`` reflects whichever
+    # class actually ran, so we trip an opt-in log_verbosity to make the
+    # log shape visible.
+    result = gmm.estimate(optimizer_kwargs={"log_verbosity": 1})
+    log = result.optimizer_report.get("log") or {}
+    iters = log.get("iterations") if isinstance(log, dict) else None
+    # The base ``TrustRegions`` never populates these keys; their
+    # presence is the signature of the logging-aware subclass running.
+    assert iters is not None
+    assert "inner_stop_code" in iters
+    assert "num_inner" in iters
+    # And that subclass is a TrustRegions, so legacy isinstance checks
+    # on user code still work.
+    assert issubclass(LoggingTrustRegions, TrustRegions)
+
+
+def test_logging_trust_regions_records_inner_state() -> None:
+    """At ``log_verbosity=1`` the per-iteration log carries inner-CG state."""
+
+    from manifoldgmm.optimizers import LoggingTrustRegions
+
+    restriction, _ = _build_simple_restriction()
+    gmm = GMM(
+        restriction,
+        initial_point=jnp.array([0.0]),
+        optimizer=LoggingTrustRegions,
+    )
+
+    result = gmm.estimate(optimizer_kwargs={"log_verbosity": 1})
+
+    iters = result.optimizer_report["log"]["iterations"]
+    # Each per-iter list has length equal to the number of recorded
+    # iterations (defaultdict semantics: a key that was never appended
+    # is just absent).
+    n = len(iters["iteration"])
+    assert n >= 1
+    assert len(iters["num_inner"]) == n
+    assert len(iters["inner_stop_code"]) == n
+    assert len(iters["gradient_norm"]) == n
+    # Inner stop codes are valid ints in TrustRegions' code range.
+    from pymanopt.optimizers import TrustRegions
+
+    valid = {
+        TrustRegions.NEGATIVE_CURVATURE,
+        TrustRegions.EXCEEDED_TR,
+        TrustRegions.REACHED_TARGET_LINEAR,
+        TrustRegions.REACHED_TARGET_SUPERLINEAR,
+        TrustRegions.MAX_INNER_ITER,
+        TrustRegions.MODEL_INCREASED,
+    }
+    for code in iters["inner_stop_code"]:
+        assert code in valid
+
+
+def test_optimizer_health_returns_none_without_log() -> None:
+    """At default ``log_verbosity`` the health fields are all None."""
+
+    from manifoldgmm import OptimizerHealth
+
+    restriction, _ = _build_simple_restriction()
+    gmm = GMM(restriction, initial_point=jnp.array([0.0]))
+
+    # log_verbosity defaults to 0 -> log["iterations"] is None.
+    result = gmm.estimate()
+    health = result.optimizer_health()
+
+    assert isinstance(health, OptimizerHealth)
+    assert health.n_iterations is None
+    assert health.inner_cap_hit_frac is None
+    assert health.tail_grad_slope is None
+    assert health.tail_window is None
+
+
+def test_optimizer_health_populated_under_logging() -> None:
+    """At ``log_verbosity=1`` the health fields are populated."""
+
+    restriction, _ = _build_simple_restriction()
+    gmm = GMM(restriction, initial_point=jnp.array([0.0]))
+
+    result = gmm.estimate(optimizer_kwargs={"log_verbosity": 1})
+    health = result.optimizer_health()
+
+    assert health.n_iterations is not None and health.n_iterations >= 1
+    # On this trivial Euclidean(1) fit the inner CG should converge
+    # well below the cap on every iteration -- cap-hit frac is 0.
+    assert health.inner_cap_hit_frac == 0.0
+    # Gradient norm should be falling, so the LS slope of log|grad| is
+    # negative.  (Don't pin a tight value -- pymanopt's exact iteration
+    # count is implementation-dependent.)
+    assert health.tail_grad_slope is not None
+    assert health.tail_grad_slope < 0.0
+    # tail_window is clamped to the available log length.
+    assert health.tail_window is not None
+    assert 2 <= health.tail_window <= health.n_iterations
+
+
+def test_optimizer_health_tail_window_clamps_to_log_length() -> None:
+    """``tail_window`` is clamped to the available log length."""
+
+    restriction, _ = _build_simple_restriction()
+    gmm = GMM(restriction, initial_point=jnp.array([0.0]))
+    result = gmm.estimate(optimizer_kwargs={"log_verbosity": 1})
+
+    n = result.optimizer_health().n_iterations
+    assert n is not None
+
+    # tail_window > n_iterations clamps to n_iterations.  The returned
+    # window may still be smaller if the tail contains non-positive
+    # gradient values that get masked out (the trivial Euclidean(1) fit
+    # can produce a zero gradient on the final iteration), so we test
+    # only the upper bound.
+    h_large = result.optimizer_health(tail_window=10_000)
+    assert h_large.tail_window is not None
+    assert h_large.tail_window <= n
+
+
+def test_optimizer_health_handles_synthetic_cap_hit_log() -> None:
+    """``inner_cap_hit_frac`` is computed correctly from a synthetic log.
+
+    Bypass the optimizer: hand-build a ``GMMResult`` (well, the bits the
+    method reads) and verify the metric arithmetic.
+    """
+
+    from manifoldgmm import OptimizerHealth
+
+    # Build the bare minimum of a GMMResult-shaped object that
+    # optimizer_health needs.  Real GMMResult instances have many more
+    # fields; we test the helper in isolation here.
+    restriction, _ = _build_simple_restriction()
+    gmm = GMM(restriction, initial_point=jnp.array([0.0]))
+    base = gmm.estimate(optimizer_kwargs={"log_verbosity": 1})
+
+    # Replace the log with a synthetic one: 10 iters, 4 of them cap-hit
+    # (num_inner == maxinner == 20), the rest with num_inner < maxinner.
+    # gradient norm 1e0, 1e-1, ..., 1e-9 (clean log-linear decay of
+    # slope -ln(10)).
+    fake_log = {
+        "iterations": {
+            "iteration": list(range(1, 11)),
+            "num_inner": [20] * 4 + [5] * 6,
+            "maxinner": [20] * 10,
+            "gradient_norm": [10.0 ** (-i) for i in range(10)],
+        }
+    }
+    object.__setattr__(
+        base, "optimizer_report", dict(base.optimizer_report, log=fake_log)
+    )
+
+    health = base.optimizer_health(tail_window=10)
+    assert isinstance(health, OptimizerHealth)
+    assert health.n_iterations == 10
+    assert health.inner_cap_hit_frac == pytest.approx(0.4)
+    # Tail-window slope of log(10**-i) on i=0..9 is -ln(10) ≈ -2.3026.
+    assert health.tail_grad_slope == pytest.approx(-np.log(10.0), rel=1e-6)
+
+
+# -----------------------------------------------------------------------
 # Canonical-Jacobian cache (#4)
 # -----------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Closes the remaining bullets of "PR 1" in #10. PR #11 fixed the latent attribute bug in `_run_stage` and added the `optimizer_kwargs` partition; this PR adds:

1. **`LoggingTrustRegions`** — a drop-in `TrustRegions` subclass that persists inner-CG state (`num_inner`, `maxinner`, `inner_stop_code`) plus `gradient_norm` to `OptimizerResult.log["iterations"]` at `log_verbosity >= 1`. No method-body duplication: two hook overrides (`_truncated_conjugate_gradient` stashes the inner state, `_check_stopping_criterion` calls the existing `_add_log_entry` with the stashed values). At `log_verbosity == 0` (pymanopt's default) the overrides are no-ops.
2. **Default optimizer for `GMM`** switched from `TrustRegions` to `LoggingTrustRegions`. Behaviour-preserving — identical control flow at `log_verbosity == 0`; additive telemetry at `log_verbosity >= 1`. Callers passing `optimizer=TrustRegions(...)` explicitly keep the old behaviour.
3. **`GMMResult.optimizer_health(tail_window=10)`** + `OptimizerHealth` dataclass. Computes `inner_cap_hit_frac` and `tail_grad_slope` cheaply from the persisted log. Both fields return `None` when the underlying log series isn't populated, so callers distinguish "no information" from a computed value of zero.

## A pymanopt quirk worth flagging

While writing the tests I tripped a behaviour in pymanopt that affects the natural cap-hit predicate: even on a trivial Euclidean(1) fit, the final iteration printed `srstr = "maximum inner iterations"` despite `num_inner = 0`. `_truncated_conjugate_gradient` pre-assumes `stop_tCG = MAX_INNER_ITER` and only overwrites on early termination — so the stop code false-positives when the inner loop body never runs (gradient already zero).

Consequence: the metric uses the strict `num_inner == maxinner` predicate, not `inner_stop_code == MAX_INNER_ITER`. The subclass logs both `num_inner` and `maxinner` per iteration (the latter is constant across a run but logged per-row so the cap-hit predicate is self-contained). Documented in the subclass docstring.

## Test plan

- [x] 6 new tests in `tests/econometrics/test_gmm.py`:
  - `test_default_optimizer_is_logging_trust_regions` — `GMM().estimate(optimizer_kwargs={"log_verbosity": 1})` surfaces `num_inner` / `inner_stop_code` in the log.
  - `test_logging_trust_regions_records_inner_state` — stop codes are valid `TrustRegions` constants; list lengths align.
  - `test_optimizer_health_returns_none_without_log` — at default `log_verbosity == 0` all fields are `None`.
  - `test_optimizer_health_populated_under_logging` — cap-hit frac is 0 for a trivial fit; gradient-norm slope is negative (converging).
  - `test_optimizer_health_tail_window_clamps_to_log_length` — upper-bound clamp respected.
  - `test_optimizer_health_handles_synthetic_cap_hit_log` — hand-built log with 4-of-10 cap hits and log-linear gradient decay verifies the arithmetic (`frac == 0.4`, `slope == -ln(10)`).
- [x] `tests/econometrics/test_gmm.py` full file: 31 passed, 0 failed (6 new + 25 pre-existing).
- [x] `ruff check`, `black --check`, `mypy` clean on the touched files.

## Scope and follow-ups

This PR deliberately stops short of the remaining items in #10:

- **`compute_hessian_cond()` via FD HVPs** (originally also under "PR 1"). The design has more shape than fits cleanly here — cost-function selection (the GMM criterion `g'Wg`, or the per-stage cost?) and FD step size in tangent units both warrant separate discussion. Deferred to a follow-up.
- **PR 2** — `warnings.warn(...)` emission when `inner_cap_hit_frac > 0.5 AND outer stop is `max iterations` AND tail-grad slope ≈ 0`. Depends on what this PR ships.
- **PR 3** — adaptive `maxinner`. Independent of `optimizer_health`; depends on the inner-CG logging.

## Why the subclass instead of a pymanopt PR

Upstream pymanopt has been quiet since 2024-09-20. The upstream patches that would let this subclass be retired are filed at pymanopt/pymanopt#302. The subclass is the working assumption; if #302 lands later, it can go away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
