### PR TITLE
Warn on optimizer stall pattern (#10 PR 2)

### DIFF
--- a/src/manifoldgmm/__init__.py
+++ b/src/manifoldgmm/__init__.py
@@ -12,6 +12,7 @@ try:
 except PackageNotFoundError:
     __version__ = "0.0.0"
 
+from ._warnings import ConvergenceWarning
 from .autodiff import jacobian_from_pymanopt, jacobian_operator
 from .econometrics import GMM, GMMResult, KStatisticResult, MomentRestriction
 from .econometrics.bootstrap import MomentWildBootstrap, geodesic_mahalanobis_distance
@@ -30,4 +31,5 @@ __all__ = [
     "MomentWildBootstrap",
     "geodesic_mahalanobis_distance",
     "monte_carlo",
+    "ConvergenceWarning",
 ]

--- a/src/manifoldgmm/_warnings.py
+++ b/src/manifoldgmm/_warnings.py
@@ -1,0 +1,41 @@
+"""Canonical warning classes for ManifoldGMM.
+
+The package CLAUDE.md lists a small set of canonical warning categories
+(``NumericalWarning``, ``GaugeWarning``, ``ConvergenceWarning``) that
+downstream code is expected to use rather than bare ``UserWarning``.
+This module is the home for those classes.  Each subclasses
+``UserWarning`` so the standard :mod:`warnings` machinery (filters,
+``warnings.simplefilter``, pytest's ``filterwarnings`` mark, etc.) works
+unchanged, while letting callers target a specific category when they
+want to silence (or escalate) just that family of diagnostics.
+
+Adding more classes here is cheap; resist the urge to add one per
+warning site.  A category buys filterability for an *audience*: users
+who care about convergence behaviour but not about numerical-conditioning
+nags, or vice versa.  If a single site is the only consumer, prefer the
+existing :class:`UserWarning`.
+"""
+
+from __future__ import annotations
+
+
+class ConvergenceWarning(UserWarning):
+    """The optimisation completed but a convergence-health check failed.
+
+    Emitted at the end of :meth:`manifoldgmm.GMM.estimate` when the
+    diagnostics in :attr:`manifoldgmm.GMMResult.optimizer_health` flag a
+    stall pattern: the outer loop ran out of budget (non-tolerance
+    stopping criterion), the inner truncated-CG repeatedly hit its
+    iteration cap, and the gradient norm stopped descending.  The
+    ``GMMResult`` is still returned -- the warning is advisory.
+
+    Filter via the standard :mod:`warnings` interface, e.g.::
+
+        import warnings
+        from manifoldgmm import ConvergenceWarning
+
+        warnings.filterwarnings("ignore", category=ConvergenceWarning)
+    """
+
+
+__all__ = ["ConvergenceWarning"]

--- a/src/manifoldgmm/econometrics/gmm.py
+++ b/src/manifoldgmm/econometrics/gmm.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pickle
+import warnings
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -22,9 +23,82 @@ from pymanopt.function import jax as pymanopt_jax_function
 from pymanopt.function import numpy as pymanopt_numpy_function
 from pymanopt.optimizers.optimizer import Optimizer
 
+from .._warnings import ConvergenceWarning
 from ..geometry import Manifold, ManifoldPoint
 from ..optimizers import LoggingTrustRegions
 from .moment_restriction import MomentRestriction
+
+# Default threshold for "tail_grad_slope ≈ 0".  Slope is in
+# log-gradient-norm per outer iteration; healthy convergence has slope
+# well below this (e.g., -0.5 near a quadratic optimum).  The
+# motivating #10 trace had slope ≈ -0.003 over 14 iterations; -0.01
+# is a tight "not actually descending" line that still admits slow
+# but real progress.
+_STALL_TAIL_SLOPE_THRESHOLD: float = -0.01
+
+# Minimum cap-hit fraction that flips the warning on.  Aligned with the
+# >0.5 phrasing in issue #10's PR 2 sketch.
+_STALL_CAP_HIT_FRAC_THRESHOLD: float = 0.5
+
+
+def _maybe_warn_optimizer_health(result: GMMResult) -> None:
+    """Emit a :class:`ConvergenceWarning` if the optimiser stalled.
+
+    Three diagnostics jointly identify the stuck-optimizer pathology
+    issue #10 was opened against:
+
+    1. Inner truncated-CG repeatedly hit ``MAX_INNER_ITER``
+       (``optimizer_health["inner_cap_hit_frac"] > 0.5``).
+    2. Outer loop terminated on a budget criterion, not a tolerance
+       (``optimizer_report["converged"] is not True``).
+    3. Gradient norm stopped descending on the tail of the trace
+       (``optimizer_health["tail_grad_slope"] > -0.01``).
+
+    Any field being ``None`` (no telemetry, fewer than two recorded
+    gradient norms, missing stopping criterion) skips the check
+    entirely -- the warning fires only when all three signals are
+    available and aligned.
+    """
+
+    health = result.optimizer_health
+    cap_frac = health.get("inner_cap_hit_frac")
+    slope = health.get("tail_grad_slope")
+    if cap_frac is None or slope is None:
+        return
+    if cap_frac <= _STALL_CAP_HIT_FRAC_THRESHOLD:
+        return
+    if slope <= _STALL_TAIL_SLOPE_THRESHOLD:
+        return
+
+    converged = (result.optimizer_report or {}).get("converged")
+    if converged is True:
+        return
+
+    stopping = (result.optimizer_report or {}).get("stopping_criterion") or ""
+    n_outer = health.get("n_outer_iters")
+    n_cap_hits = health.get("n_inner_cap_hits")
+    tail_window = health.get("tail_window")
+
+    message = (
+        "Optimisation may have stalled before reaching a tolerance:\n"
+        f"  inner_cap_hit_frac = {cap_frac:.2f}  "
+        f"({n_cap_hits} of {sum(health.get('inner_stop_counts', {}).values())} "
+        f"inner solves hit MAX_INNER_ITER)\n"
+        f"  tail_grad_slope    = {slope:+.4f}  "
+        f"(d log|grad| / d iter over the last {tail_window} iters; "
+        f"healthy convergence is more negative than "
+        f"{_STALL_TAIL_SLOPE_THRESHOLD})\n"
+        f"  outer iterations   = {n_outer}, stopping_criterion = "
+        f"{stopping!r}\n"
+        "Remediation:\n"
+        "  - Raise the inner-CG iteration cap, e.g.\n"
+        "      gmm.estimate(optimizer_kwargs={'maxinner': <larger>})\n"
+        "    pymanopt's default is manifold.dim; doubling it is a cheap first try.\n"
+        "  - Inspect curvature with result.compute_hessian_cond(); large\n"
+        "    values (>> 1e6) suggest the geometry itself is poorly\n"
+        "    identified rather than the optimiser being underpowered."
+    )
+    warnings.warn(message, ConvergenceWarning, stacklevel=3)
 
 
 class WeightingStrategy(Protocol):
@@ -1292,7 +1366,7 @@ class GMM:
         weighting_info["converged"] = converged
         weighting_info["tol"] = float(weighting_tol)
 
-        return GMMResult(
+        result = GMMResult(
             _theta=final_stage.theta,
             criterion_value=float(
                 self._backend_dot(final_stage.theta, final_weighting)
@@ -1305,6 +1379,8 @@ class GMM:
             g_bar=final_stage.g_bar,
             two_step=first_stage_reweighted,
         )
+        _maybe_warn_optimizer_health(result)
+        return result
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/tests/test_logging_trust_regions.py
+++ b/tests/test_logging_trust_regions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import Any
 
 import jax.numpy as jnp
@@ -327,3 +328,199 @@ def test_compute_hessian_cond_handles_missing_weighting() -> None:
     bare = dc_replace(result, weighting=None)
     with pytest.raises(ValueError, match="weighting"):
         bare.compute_hessian_cond()
+
+
+# -----------------------------------------------------------------------
+# ConvergenceWarning on stall (#10 PR 2)
+# -----------------------------------------------------------------------
+
+
+def _force_optimizer_report(
+    result: Any,
+    *,
+    log: dict[str, Any],
+    converged: bool | None,
+    stopping_criterion: str,
+    iterations: int,
+) -> Any:
+    """Replace ``optimizer_report`` on a real GMMResult with a synthetic one.
+
+    Used to test ``_maybe_warn_optimizer_health`` without having to drive
+    an actual estimator into the stall pathology.
+    """
+
+    fake_report = dict(result.optimizer_report)
+    fake_report.update(
+        log=log,
+        converged=converged,
+        stopping_criterion=stopping_criterion,
+        iterations=iterations,
+    )
+    object.__setattr__(result, "optimizer_report", fake_report)
+    return result
+
+
+def test_healthy_fit_emits_no_convergence_warning() -> None:
+    """A clean Euclidean(1) fit should not trigger the stall warning."""
+
+    from manifoldgmm import ConvergenceWarning
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", category=ConvergenceWarning)
+        # If estimate() emits ConvergenceWarning the simplefilter("error")
+        # promotes it to a raised exception, failing the test.
+        _ = _simple_fit()
+
+
+def test_convergence_warning_fires_on_synthetic_stall() -> None:
+    """All three stall conditions present -> ConvergenceWarning is emitted."""
+
+    from manifoldgmm import ConvergenceWarning
+
+    base = _simple_fit()
+    fake_log = {
+        # 14 cap hits out of 16 inner solves -> cap_frac = 0.875 > 0.5.
+        "inner_stop_counts": {
+            "maximum inner iterations": 14,
+            "exceeded trust region": 2,
+        },
+        # Flat tail: gradient norm barely moves over ~14 iters.
+        # log slope on these is approximately -0.003 per step,
+        # well above (less negative than) the -0.01 threshold.
+        "gradient_norms": [
+            4.20e-3,
+            4.18e-3,
+            4.16e-3,
+            4.15e-3,
+            4.13e-3,
+            4.11e-3,
+            4.10e-3,
+            4.09e-3,
+            4.08e-3,
+            4.07e-3,
+            4.06e-3,
+            4.05e-3,
+            4.04e-3,
+            4.03e-3,
+            4.02e-3,
+        ],
+    }
+    stalled = _force_optimizer_report(
+        base,
+        log=fake_log,
+        converged=False,
+        stopping_criterion=(
+            "Terminated - max iterations reached after 200.00 seconds."
+        ),
+        iterations=14,
+    )
+
+    # We invoke the warning helper directly with the patched result
+    # (estimate() already returned; the in-flight warning has fired or
+    # not based on the *original* report).
+    from manifoldgmm.econometrics.gmm import _maybe_warn_optimizer_health
+
+    with pytest.warns(ConvergenceWarning) as record:
+        _maybe_warn_optimizer_health(stalled)
+
+    assert len(record) == 1
+    message = str(record[0].message)
+    # The remediation hint should mention both maxinner and
+    # compute_hessian_cond, per issue #10's PR 2 spec.
+    assert "maxinner" in message
+    assert "compute_hessian_cond" in message
+    # And the diagnostics that drove the decision should be visible.
+    assert "inner_cap_hit_frac" in message
+    assert "tail_grad_slope" in message
+
+
+def test_convergence_warning_silent_when_telemetry_missing() -> None:
+    """No warning when the log lacks the inputs the helper needs.
+
+    A third-party optimizer (or a user run at ``log_verbosity=0`` against
+    plain ``TrustRegions``) won't have ``inner_stop_counts`` or
+    ``gradient_norms``; the helper must short-circuit rather than fire
+    spuriously.
+    """
+
+    from manifoldgmm import ConvergenceWarning
+    from manifoldgmm.econometrics.gmm import _maybe_warn_optimizer_health
+
+    base = _simple_fit()
+    bare = _force_optimizer_report(
+        base,
+        log={},  # no inner_stop_counts, no gradient_norms
+        converged=False,
+        stopping_criterion="Terminated - max iterations reached.",
+        iterations=14,
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", category=ConvergenceWarning)
+        _maybe_warn_optimizer_health(bare)
+
+
+def test_convergence_warning_silent_on_tolerance_stop() -> None:
+    """A converged=True run skips the warning even with high cap_frac.
+
+    Cap-hit fraction can plausibly be > 0.5 on hard problems that still
+    reach a tolerance.  The discriminating signal for "stuck" is that
+    the outer loop ran out of budget, so converged=True suppresses.
+    """
+
+    from manifoldgmm import ConvergenceWarning
+    from manifoldgmm.econometrics.gmm import _maybe_warn_optimizer_health
+
+    base = _simple_fit()
+    high_cap = _force_optimizer_report(
+        base,
+        log={
+            "inner_stop_counts": {
+                "maximum inner iterations": 9,
+                "exceeded trust region": 1,
+            },
+            "gradient_norms": [1.0, 0.1, 0.01],  # healthy slope ~ -2.3 per iter
+        },
+        converged=True,
+        stopping_criterion="Terminated - min grad norm reached.",
+        iterations=3,
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", category=ConvergenceWarning)
+        _maybe_warn_optimizer_health(high_cap)
+
+
+def test_convergence_warning_silent_when_slope_is_descending() -> None:
+    """No warning when the gradient is still falling, even if the cap fires.
+
+    Two of three conditions met (cap_frac high, max_iters stop) but the
+    gradient is still genuinely descending -- the optimiser was making
+    progress and just hit the iteration budget.  Bumping max_iterations,
+    not maxinner, is the right remediation, so the stall warning would
+    be misleading.
+    """
+
+    from manifoldgmm import ConvergenceWarning
+    from manifoldgmm.econometrics.gmm import _maybe_warn_optimizer_health
+
+    base = _simple_fit()
+    descending = _force_optimizer_report(
+        base,
+        log={
+            "inner_stop_counts": {
+                "maximum inner iterations": 12,
+                "exceeded trust region": 2,
+            },
+            "gradient_norms": [
+                10 ** (-i) for i in range(14)
+            ],  # slope = -ln(10) per iter
+        },
+        converged=False,
+        stopping_criterion="Terminated - max iterations reached.",
+        iterations=14,
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", category=ConvergenceWarning)
+        _maybe_warn_optimizer_health(descending)


### PR DESCRIPTION
## Summary

Closes PR 2 in the sequence from #10. After PR #11 (latent attribute bug) and PR #12 (LoggingTrustRegions + optimizer_health + compute_hessian_cond), this PR ships the small derived warning that ties the three telemetry signals together into a single user-facing diagnostic.

A `ConvergenceWarning` fires at the end of `GMM.estimate()` when all three of these hold:

1. `optimizer_health["inner_cap_hit_frac"] > 0.5` — inner truncated-CG repeatedly hit `MAX_INNER_ITER`.
2. `optimizer_report["converged"] is not True` — outer loop ran out of budget rather than reaching a tolerance.
3. `optimizer_health["tail_grad_slope"] > -0.01` — log gradient norm not descending on the tail window.

Any field being `None` short-circuits the check, so third-party optimizers and `log_verbosity=0` runs see no spurious warnings.

## The `tail_grad_slope > -0.01` threshold

The motivating #10 trace had `|grad|` going from `4.17e-3` to `4.02e-3` over 14 iterations — log slope `≈ -0.003` per outer iter. Healthy convergence near a quadratic optimum has slope `<= -0.5` (gradient norm dropping by `e^0.5 ≈ 1.6x` per iter, often much more). `-0.01` is a tight "not actually descending" line that still admits slow but real progress, and was the threshold I tuned the synthetic-stall test against.

Both thresholds live as module-level constants (`_STALL_CAP_HIT_FRAC_THRESHOLD`, `_STALL_TAIL_SLOPE_THRESHOLD`) — patchable for tests, easy to tune later.

## Why a new warning class (`ConvergenceWarning`)

CLAUDE.md lists `ConvergenceWarning` alongside `NumericalWarning` and `GaugeWarning` as canonical categories, but none of them exist in the source yet. This PR adds the first one. The new module `src/manifoldgmm/_warnings.py` is intended as the home for the other two when they pick up consumers. Each subclasses `UserWarning` so the standard `warnings` machinery works unchanged, but a downstream user who wants to silence just stall warnings can do:

```python
import warnings
from manifoldgmm import ConvergenceWarning
warnings.filterwarnings("ignore", category=ConvergenceWarning)
```

## Remediation hint

Per the spec in #10's PR 2 sketch, the warning text references both knobs:

```
Remediation:
  - Raise the inner-CG iteration cap, e.g.
      gmm.estimate(optimizer_kwargs={'maxinner': <larger>})
    pymanopt's default is manifold.dim; doubling it is a cheap first try.
  - Inspect curvature with result.compute_hessian_cond(); large
    values (>> 1e6) suggest the geometry itself is poorly
    identified rather than the optimiser being underpowered.
```

## Test plan

Five new tests in `tests/test_logging_trust_regions.py`:

- [x] `test_healthy_fit_emits_no_convergence_warning` — `warnings.simplefilter("error", ConvergenceWarning)` guard around a clean Euclidean(1) fit; the test fails if `estimate()` emits the warning.
- [x] `test_convergence_warning_fires_on_synthetic_stall` — hand-built `optimizer_report` with cap_hit_frac=0.875, flat tail slope ≈ -0.003, `converged=False`, max-iters stopping criterion. `pytest.warns(ConvergenceWarning)`; message contains `maxinner`, `compute_hessian_cond`, `inner_cap_hit_frac`, `tail_grad_slope`.
- [x] `test_convergence_warning_silent_when_telemetry_missing` — empty `log` dict (third-party optimizer scenario); helper short-circuits.
- [x] `test_convergence_warning_silent_on_tolerance_stop` — high `cap_frac` but `converged=True`; cap-hits on tolerance-converged fits are legitimate (hard problems near boundary etc.), so no warning.
- [x] `test_convergence_warning_silent_when_slope_is_descending` — `cap_frac` high AND `converged=False` AND gradient is still descending (slope `= -ln(10) ≈ -2.3`). Two of three conditions met but the third disambiguates: bumping `max_iterations` is the right remediation, not `maxinner`, so silence the warning to avoid misleading users.
- [x] Existing tests in `tests/test_logging_trust_regions.py`, `tests/econometrics/test_gmm.py`, `tests/econometrics/test_moment_restriction.py` all still pass — 57 total.
- [x] `ruff check`, `black --check`, `mypy` clean on touched files.

## Out of scope

- **PR 3** (adaptive `maxinner` policy) — independent of this PR; depends on the same telemetry.
- **Hessian ridging** — the deferred follow-up in #10. The warning text now nudges users toward `compute_hessian_cond` as a diagnostic; whether to also act on that diagnostic (e.g. an opt-in Hessian ridge analogous to `CUEWeighting`'s Ω ridge) is the design question that should come later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
