### PR TITLE
Adaptive maxinner policy (#10 PR 3)

### DIFF
--- a/src/manifoldgmm/optimizers/logging_trust_regions.py
+++ b/src/manifoldgmm/optimizers/logging_trust_regions.py
@@ -11,6 +11,13 @@ from typing import Any
 from pymanopt.optimizers import TrustRegions
 from pymanopt.optimizers.optimizer import OptimizerResult
 
+# Defaults for the opt-in adaptive-maxinner policy (#10 PR 3).  Constants
+# rather than buried magic numbers so tests can patch and downstream can
+# read the chosen tuning.
+_DEFAULT_ADAPTIVE_THRESHOLD: float = 0.6
+_DEFAULT_ADAPTIVE_WINDOW: int = 5
+_DEFAULT_ADAPTIVE_CEILING_FACTOR: int = 8
+
 
 class LoggingTrustRegions(TrustRegions):
     """Drop-in TrustRegions replacement that captures per-iter telemetry.
@@ -29,6 +36,20 @@ class LoggingTrustRegions(TrustRegions):
       initialisation plus one per *accepted* outer iteration; rejected
       steps reuse the previous gradient.
 
+    When ``adaptive_maxinner=True`` (opt-in; see :meth:`__init__`), two
+    additional log keys are populated:
+
+    - ``maxinner_history``: a ``list[int]`` of the ``maxinner`` value
+      passed to each inner truncated-CG call.  Constant when the policy
+      stays quiet; ratchets up when the rolling cap-hit window crosses
+      the threshold.
+    - ``numit_history``: a ``list[int]`` of the actual inner iteration
+      counts.  Lets downstream code compute the *strict*
+      ``numit == maxinner`` cap-hit predicate, which avoids pymanopt's
+      false-positive where ``stop_code == MAX_INNER_ITER`` is
+      pre-assumed and stays put when the inner loop body never runs
+      (e.g., gradient already zero, ``numit == 0``).
+
     Telemetry overhead is one ``Counter`` increment per outer iteration
     and one ``float`` cast plus list append per gradient call -- both
     negligible relative to the inner-CG / Hessian work pymanopt performs.
@@ -39,7 +60,9 @@ class LoggingTrustRegions(TrustRegions):
     :meth:`TrustRegions.run`.  Instead it:
 
     1. Overrides :meth:`_truncated_conjugate_gradient` to tally
-       ``stop_inner`` codes (one increment per outer iter).
+       ``stop_inner`` codes (one increment per outer iter), and, when
+       adaptive mode is active, substitutes its own ``maxinner`` for
+       the local value pymanopt's ``run`` passed in.
     2. In :meth:`run`, sets the backing attribute
        ``problem._riemannian_gradient`` to a wrapping closure that
        records the post-call norm.  Pymanopt's property lazy-resolves
@@ -49,27 +72,145 @@ class LoggingTrustRegions(TrustRegions):
        same ``Problem`` see no permanent mutation.
 
     If pymanopt later adds ``_add_log_entry`` calls inside
-    :meth:`TrustRegions.run`, this subclass becomes redundant and can be
-    deleted in favour of using ``TrustRegions`` directly with
-    ``log_verbosity=1``.
+    :meth:`TrustRegions.run`, the telemetry parts of this subclass
+    become redundant and can be deleted in favour of using
+    ``TrustRegions`` directly with ``log_verbosity=1``.  The adaptive-
+    maxinner policy would still need a subclass because pymanopt's
+    ``run`` reads ``maxinner`` from a local, not an attribute.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        *args: Any,
+        adaptive_maxinner: bool = False,
+        adaptive_threshold: float = _DEFAULT_ADAPTIVE_THRESHOLD,
+        adaptive_window: int = _DEFAULT_ADAPTIVE_WINDOW,
+        adaptive_ceiling: int | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Construct a logging TrustRegions optimizer.
+
+        Parameters
+        ----------
+        adaptive_maxinner:
+            Opt-in to the adaptive-maxinner policy (#10 PR 3).  When
+            enabled, the optimizer doubles ``maxinner`` whenever a
+            rolling window of recent outer iterations crossed the
+            ``adaptive_threshold`` fraction of cap-hits.  The current
+            ``maxinner`` value is exposed per-iteration via
+            ``result.log["maxinner_history"]``.
+        adaptive_threshold:
+            Fraction of the rolling window that must hit the cap to
+            trigger a doubling.  Default ``0.6``.  The cap-hit predicate
+            is the strict ``numit >= current_maxinner``, not the
+            stop-code string-match -- avoids pymanopt's false-positive
+            when ``numit == 0`` (see class docstring).
+        adaptive_window:
+            Size of the rolling window used to compute the cap-hit
+            fraction.  Default ``5``.
+        adaptive_ceiling:
+            Upper bound on ``maxinner``.  ``None`` (default) resolves at
+            ``run()`` to ``8 * starting_maxinner`` (i.e., ``8 *
+            manifold.dim`` when ``maxinner`` is not explicitly passed),
+            which allows three doublings before saturating.  Pass an
+            explicit integer to override; pass ``float('inf')`` to
+            disable the bound entirely (use with caution -- pathological
+            problems can push ``maxinner`` indefinitely).
+        *args, **kwargs:
+            Forwarded to :class:`TrustRegions.__init__`.
+        """
+
         super().__init__(*args, **kwargs)
         self._inner_stop_counts: collections.Counter[int] = collections.Counter()
         self._iter_gradient_norms: list[float] = []
+        # Adaptive policy state.
+        self._adaptive_maxinner: bool = bool(adaptive_maxinner)
+        self._adaptive_threshold: float = float(adaptive_threshold)
+        self._adaptive_window: int = int(adaptive_window)
+        # Note ``None`` here distinguishes "use the 8x default" from
+        # ``float('inf')`` ("explicitly no ceiling").  Resolved at run().
+        self._adaptive_ceiling: int | float | None = adaptive_ceiling
+        self._current_maxinner: int | None = None
+        self._maxinner_history: list[int] = []
+        self._numit_history: list[int] = []
 
     def _reset_telemetry(self) -> None:
         self._inner_stop_counts = collections.Counter()
         self._iter_gradient_norms = []
+        self._current_maxinner = None
+        self._maxinner_history = []
+        self._numit_history = []
 
     def _truncated_conjugate_gradient(
-        self, *args: Any, **kwargs: Any
+        self,
+        problem: Any,
+        x: Any,
+        fgradx: Any,
+        eta: Any,
+        Delta: Any,
+        theta: Any,
+        kappa: Any,
+        mininner: int,
+        maxinner: int,
     ) -> tuple[Any, Any, int, int]:
-        result = super()._truncated_conjugate_gradient(*args, **kwargs)
-        eta, Heta, numit, stop_inner = result
+        # Adaptive override: ignore the local ``maxinner`` from pymanopt's
+        # ``run`` (it's a frozen-at-entry local) and use the value the
+        # adaptive policy has been ratcheting.  ``_current_maxinner`` is
+        # initialised in ``run`` to mirror pymanopt's default so the
+        # first call is identical to the non-adaptive case.
+        if self._adaptive_maxinner and self._current_maxinner is not None:
+            effective = self._current_maxinner
+        else:
+            effective = int(maxinner)
+
+        self._maxinner_history.append(effective)
+
+        result = super()._truncated_conjugate_gradient(
+            problem, x, fgradx, eta, Delta, theta, kappa, mininner, effective
+        )
+        eta_out, Heta_out, numit, stop_inner = result
         self._inner_stop_counts[stop_inner] += 1
+        self._numit_history.append(int(numit))
+
+        if self._adaptive_maxinner:
+            self._maybe_double_maxinner(effective)
+
         return result
+
+    def _maybe_double_maxinner(self, current: int) -> None:
+        """Update ``_current_maxinner`` based on the rolling cap-hit window.
+
+        Strict cap-hit predicate: ``numit >= maxinner_used_that_iter``.
+        Uses :attr:`_numit_history` and :attr:`_maxinner_history` (both
+        ordered, same length).  Closes #10 PR 3.
+        """
+
+        recent_numit = self._numit_history[-self._adaptive_window :]
+        recent_max = self._maxinner_history[-self._adaptive_window :]
+        if len(recent_numit) < self._adaptive_window:
+            return
+        cap_hits = sum(
+            1 for n, m in zip(recent_numit, recent_max, strict=False) if n >= m
+        )
+        cap_frac = cap_hits / len(recent_numit)
+        if cap_frac < self._adaptive_threshold:
+            return
+
+        proposed = current * 2
+        ceiling = self._adaptive_ceiling
+        # ``None`` means "use 8x starting" but starting is whatever
+        # run() initialised ``_current_maxinner`` to, which is what
+        # ``current`` already reflects when we haven't doubled yet.
+        # We need the *initial* maxinner, which we cache as
+        # ``self._adaptive_starting_maxinner`` in run().
+        if ceiling is None:
+            ceiling = (
+                _DEFAULT_ADAPTIVE_CEILING_FACTOR * self._adaptive_starting_maxinner
+            )
+        if proposed > ceiling:
+            proposed = int(ceiling) if ceiling != float("inf") else proposed
+        if proposed > current:
+            self._current_maxinner = int(proposed)
 
     def run(
         self, problem: Any, *, initial_point: Any = None, **kwargs: Any
@@ -77,6 +218,19 @@ class LoggingTrustRegions(TrustRegions):
         self._reset_telemetry()
 
         manifold = problem.manifold
+
+        # Adaptive maxinner setup: mirror pymanopt's ``maxinner`` resolution
+        # so our state starts at the same value the non-adaptive run would
+        # use.  Pymanopt's default is ``manifold.dim``; an explicit kwarg
+        # overrides.
+        if self._adaptive_maxinner:
+            passed_maxinner = kwargs.get("maxinner")
+            if passed_maxinner is None:
+                # Mirror pymanopt's ``if maxinner is None: maxinner = manifold.dim``.
+                passed_maxinner = manifold.dim
+            self._adaptive_starting_maxinner = int(passed_maxinner)
+            self._current_maxinner = int(passed_maxinner)
+
         # Resolve the gradient function through the property first so the
         # lazy fallback (euclidean->riemannian) runs once and writes to
         # ``_riemannian_gradient``.  After that we wrap it in place.
@@ -106,6 +260,9 @@ class LoggingTrustRegions(TrustRegions):
             for code, count in self._inner_stop_counts.items()
         }
         result.log["gradient_norms"] = list(self._iter_gradient_norms)
+        if self._adaptive_maxinner:
+            result.log["maxinner_history"] = list(self._maxinner_history)
+            result.log["numit_history"] = list(self._numit_history)
         return result
 
 

--- a/src/manifoldgmm/optimizers/logging_trust_regions.py
+++ b/src/manifoldgmm/optimizers/logging_trust_regions.py
@@ -85,7 +85,7 @@ class LoggingTrustRegions(TrustRegions):
         adaptive_maxinner: bool = False,
         adaptive_threshold: float = _DEFAULT_ADAPTIVE_THRESHOLD,
         adaptive_window: int = _DEFAULT_ADAPTIVE_WINDOW,
-        adaptive_ceiling: int | None = None,
+        adaptive_ceiling: int | float | None = None,
         **kwargs: Any,
     ) -> None:
         """Construct a logging TrustRegions optimizer.

--- a/tests/test_logging_trust_regions.py
+++ b/tests/test_logging_trust_regions.py
@@ -524,3 +524,215 @@ def test_convergence_warning_silent_when_slope_is_descending() -> None:
     with warnings.catch_warnings():
         warnings.simplefilter("error", category=ConvergenceWarning)
         _maybe_warn_optimizer_health(descending)
+
+
+# -----------------------------------------------------------------------
+# Adaptive maxinner policy (#10 PR 3)
+# -----------------------------------------------------------------------
+
+
+def test_adaptive_maxinner_off_by_default() -> None:
+    """Default LoggingTrustRegions matches PR #12 behaviour exactly."""
+
+    opt = LoggingTrustRegions()
+    assert opt._adaptive_maxinner is False
+    # No adaptive log keys when adaptive is off.
+    result = _simple_fit()
+    log = result.optimizer_report["log"]
+    assert "maxinner_history" not in log
+    assert "numit_history" not in log
+
+
+def test_adaptive_maxinner_records_history_on_real_fit() -> None:
+    """When opted in, the adaptive log keys appear and are sane."""
+
+    data = jnp.array([1.0, 2.0, 3.0, 4.0, 5.0])
+
+    def gi_jax(theta: Any, observation: Any) -> Any:
+        return observation - theta[0]
+
+    manifold = Manifold.from_pymanopt(PymanoptEuclidean(1))
+    restriction = MomentRestriction(
+        gi_jax=gi_jax, data=data, manifold=manifold, backend="jax"
+    )
+    gmm = GMM(restriction, initial_point=jnp.array([0.0]))
+    result = gmm.estimate(optimizer_kwargs={"adaptive_maxinner": True})
+
+    log = result.optimizer_report["log"]
+    history = log["maxinner_history"]
+    numit_history = log["numit_history"]
+    assert len(history) == len(numit_history)
+    # Healthy convergence on Euclidean(1): maxinner should stay constant
+    # at the starting value (manifold.dim = 1).  No doublings expected.
+    assert all(m == history[0] for m in history), (
+        f"healthy Euclidean(1) fit should not trigger adaptive doubling; "
+        f"saw history {history}"
+    )
+
+
+def test_adaptive_maxinner_doubles_when_window_caps() -> None:
+    """The doubling logic fires when ``adaptive_window`` recent iters cap.
+
+    Unit-tests the policy by hand-driving ``_maybe_double_maxinner`` rather
+    than running an optimizer to the stuck state.
+    """
+
+    opt = LoggingTrustRegions(
+        adaptive_maxinner=True,
+        adaptive_window=5,
+        adaptive_threshold=0.6,
+        adaptive_ceiling=float("inf"),
+    )
+    opt._adaptive_starting_maxinner = 4
+    opt._current_maxinner = 4
+
+    # 5 consecutive iterations each hitting numit == maxinner == 4.
+    for _ in range(5):
+        opt._numit_history.append(4)
+        opt._maxinner_history.append(4)
+    opt._maybe_double_maxinner(4)
+    assert opt._current_maxinner == 8, (
+        f"after 5/5 cap hits the policy should double 4 -> 8; "
+        f"got {opt._current_maxinner}"
+    )
+
+
+def test_adaptive_maxinner_holds_when_window_short() -> None:
+    """The policy waits for a full window before evaluating cap-hit rate."""
+
+    opt = LoggingTrustRegions(
+        adaptive_maxinner=True,
+        adaptive_window=5,
+        adaptive_ceiling=float("inf"),
+    )
+    opt._adaptive_starting_maxinner = 4
+    opt._current_maxinner = 4
+
+    # 4 cap hits but window is 5; should not yet trigger.
+    for _ in range(4):
+        opt._numit_history.append(4)
+        opt._maxinner_history.append(4)
+    opt._maybe_double_maxinner(4)
+    assert opt._current_maxinner == 4, (
+        f"adaptive should not act with fewer than window entries; "
+        f"got {opt._current_maxinner}"
+    )
+
+
+def test_adaptive_maxinner_respects_ceiling() -> None:
+    """Doublings stop at ``adaptive_ceiling``."""
+
+    opt = LoggingTrustRegions(
+        adaptive_maxinner=True,
+        adaptive_window=3,
+        adaptive_threshold=0.5,
+        adaptive_ceiling=10,
+    )
+    opt._adaptive_starting_maxinner = 4
+    opt._current_maxinner = 8  # already past one doubling
+
+    for _ in range(3):
+        opt._numit_history.append(8)
+        opt._maxinner_history.append(8)
+    opt._maybe_double_maxinner(8)
+    # Proposed 16, capped at 10.
+    assert opt._current_maxinner == 10
+
+
+def test_adaptive_maxinner_default_ceiling_is_8x_starting() -> None:
+    """Unspecified ``adaptive_ceiling`` resolves to 8 * starting_maxinner."""
+
+    opt = LoggingTrustRegions(
+        adaptive_maxinner=True,
+        adaptive_window=3,
+        adaptive_threshold=0.5,
+        # adaptive_ceiling left at default (None)
+    )
+    opt._adaptive_starting_maxinner = 4  # 8x = 32
+    opt._current_maxinner = 4
+
+    # Drive the policy until it saturates.
+    for _ in range(20):
+        opt._numit_history.append(opt._current_maxinner)
+        opt._maxinner_history.append(opt._current_maxinner)
+        opt._maybe_double_maxinner(opt._current_maxinner)
+
+    # Final value must be at most 8 * starting_maxinner = 32.
+    assert opt._current_maxinner <= 32
+    # And -- having had ample window to ratchet -- should reach the ceiling.
+    assert opt._current_maxinner == 32
+
+
+def test_adaptive_maxinner_no_action_when_under_threshold() -> None:
+    """Cap-hit fraction below threshold leaves maxinner alone."""
+
+    opt = LoggingTrustRegions(
+        adaptive_maxinner=True,
+        adaptive_window=5,
+        adaptive_threshold=0.6,
+        adaptive_ceiling=float("inf"),
+    )
+    opt._adaptive_starting_maxinner = 4
+    opt._current_maxinner = 4
+
+    # 2 cap hits out of 5 = 0.4 < 0.6.
+    opt._numit_history.extend([4, 4, 1, 1, 1])
+    opt._maxinner_history.extend([4, 4, 4, 4, 4])
+    opt._maybe_double_maxinner(4)
+    assert opt._current_maxinner == 4
+
+
+def test_adaptive_maxinner_off_does_not_log_history() -> None:
+    """``adaptive_maxinner=False`` (default) keeps the log key set unchanged."""
+
+    data = jnp.array([1.0, 2.0])
+
+    def gi_jax(theta: Any, observation: Any) -> Any:
+        return observation - theta[0]
+
+    manifold = Manifold.from_pymanopt(PymanoptEuclidean(1))
+    restriction = MomentRestriction(
+        gi_jax=gi_jax, data=data, manifold=manifold, backend="jax"
+    )
+    gmm = GMM(restriction, initial_point=jnp.array([0.0]))
+    # Default: adaptive_maxinner not passed -> off.
+    result = gmm.estimate()
+    log = result.optimizer_report["log"]
+    assert "maxinner_history" not in log
+    assert "numit_history" not in log
+
+
+def test_adaptive_maxinner_uses_strict_predicate() -> None:
+    """Cap-hit predicate is ``numit >= maxinner``, not the stop code.
+
+    Pymanopt pre-assumes ``stop_code = MAX_INNER_ITER`` and only
+    overwrites on early termination, so the stop code falsely reads
+    cap-hit when the inner loop body never runs (``numit == 0``).  The
+    adaptive policy must use the strict ``numit >= maxinner`` predicate
+    to avoid doubling on those false positives.
+    """
+
+    opt = LoggingTrustRegions(
+        adaptive_maxinner=True,
+        adaptive_window=5,
+        adaptive_threshold=0.6,
+        adaptive_ceiling=float("inf"),
+    )
+    opt._adaptive_starting_maxinner = 4
+    opt._current_maxinner = 4
+
+    # Every iteration has stop_code = MAX_INNER_ITER (pymanopt's
+    # pre-assumption) but numit == 0 (loop body never ran).  Strict
+    # predicate says 0 < 4 -> no cap hits -> no doubling.
+    opt._numit_history.extend([0, 0, 0, 0, 0])
+    opt._maxinner_history.extend([4, 4, 4, 4, 4])
+    # Simulate the stop-code Counter saying "5 cap hits" -- we ignore
+    # it in the predicate.
+    from pymanopt.optimizers import TrustRegions
+
+    opt._inner_stop_counts[TrustRegions.MAX_INNER_ITER] = 5
+
+    opt._maybe_double_maxinner(4)
+    assert (
+        opt._current_maxinner == 4
+    ), "strict predicate should not count num_inner=0 false positives"


### PR DESCRIPTION
## Summary

Closes PR 3 of #10: opt-in adaptive `maxinner` policy that grows the inner-CG iteration cap during a run when the rolling cap-hit fraction crosses a threshold.

Four new kwargs on `LoggingTrustRegions.__init__`:

| kwarg | default | meaning |
|---|---|---|
| `adaptive_maxinner` | `False` | opt-in flag |
| `adaptive_threshold` | `0.6` | fraction of recent window that must cap-hit to trigger doubling |
| `adaptive_window` | `5` | rolling window size |
| `adaptive_ceiling` | `None` | upper bound; `None` resolves to `8 * starting_maxinner` at `run()` (allows three doublings) |

Used via:

```python
gmm.estimate(optimizer_kwargs={"adaptive_maxinner": True})
```

The existing `_OPTIMIZER_RUN_KWARGS` partition (PR #11) already routes constructor kwargs correctly, so no change to `_resolve_optimizer`.

## Implementation

The override sits in `_truncated_conjugate_gradient`: ignore pymanopt's local `maxinner` (frozen at `run()` entry) and substitute `self._current_maxinner`. After each call, `_maybe_double_maxinner` inspects the recent window of `(numit, maxinner_used)` pairs and doubles when the cap-hit fraction crosses the threshold, capped at the ceiling.

No 270-line `run()` body duplication — the policy lives entirely in the two existing hooks the subclass already overrides.

## Cap-hit predicate: strict `numit >= maxinner`, not stop-code

Pymanopt pre-assumes `stop_code = MAX_INNER_ITER` at the top of `_truncated_conjugate_gradient` and only overwrites on early termination, so the stop code false-positives when the inner loop body never runs (`numit == 0`, e.g. gradient already zero). This is the same quirk I flagged when closing PR #13 — the adaptive policy *must not* double on those false positives, so it uses the strict `numit >= maxinner_used_that_iter` predicate.

Tested directly: `test_adaptive_maxinner_uses_strict_predicate` constructs 5 iterations with `numit=0` and `stop_code=MAX_INNER_ITER` (the pre-assumption); the policy correctly refuses to double.

## New log keys (only when `adaptive_maxinner=True`)

- `maxinner_history: list[int]` — the value passed to each TCG call. Constant when the policy stays quiet, ratchets when triggered.
- `numit_history: list[int]` — actual inner iteration counts per call. Lets downstream code compute the strict cap-hit predicate from the result without re-running.

These are gated on the opt-in flag so existing PR #12 consumers see no log-shape change.

## Test plan

Nine new tests in `tests/test_logging_trust_regions.py`:

- [x] `test_adaptive_maxinner_off_by_default` — no `maxinner_history` / `numit_history` keys in the log when not opted in.
- [x] `test_adaptive_maxinner_records_history_on_real_fit` — `adaptive_maxinner=True` with real Euclidean(1) fit: history is constant (trivial fit doesn't trigger cap-hits).
- [x] `test_adaptive_maxinner_doubles_when_window_caps` — drive `_maybe_double_maxinner` with 5/5 cap hits at maxinner=4; expect doubling to 8.
- [x] `test_adaptive_maxinner_holds_when_window_short` — 4 cap hits with window=5; no action until window full.
- [x] `test_adaptive_maxinner_respects_ceiling` — explicit `adaptive_ceiling=10`; doubling 8→16 capped at 10.
- [x] `test_adaptive_maxinner_default_ceiling_is_8x_starting` — saturates at 8x starting after enough driven iterations.
- [x] `test_adaptive_maxinner_no_action_when_under_threshold` — 2/5 cap hits = 0.4 < 0.6; no action.
- [x] `test_adaptive_maxinner_off_does_not_log_history` — kwarg omitted → log keys absent.
- [x] `test_adaptive_maxinner_uses_strict_predicate` — 5 iters with `numit=0` and pre-assumed `MAX_INNER_ITER` stop code → no doubling.
- [x] Pre-existing tests (12 in this file, 25 in `test_gmm.py`) all still pass — 46 total.
- [x] `ruff check`, `black --check`, `mypy` clean.

## Tuning defaults

The defaults (`threshold=0.6`, `window=5`, `ceiling=8x`) come from the issue's "if a rolling fraction of recent outer iters hits the cap, double" spec, with sensible-feeling numbers. Calibration against real benchmark data — once PR #14's `ConvergenceWarning` telemetry has surfaced enough stuck-run cases to fit against — is the natural follow-up. The values are module-level constants (`_DEFAULT_ADAPTIVE_THRESHOLD`, `_DEFAULT_ADAPTIVE_WINDOW`, `_DEFAULT_ADAPTIVE_CEILING_FACTOR`) so tuning won't ripple through the API.

## Out of scope

- **Hessian-ridge regularisation** — the deferred follow-up in #10. With PRs 11/12/14/15 (this one), the optimizer-telemetry side of #10 is now substantially closed. Hessian ridging is a separate design (the warning text already nudges users toward `compute_hessian_cond` as a diagnostic; whether to *act* on that signal is the next conversation).
- **Tighter integration with PR 14's `ConvergenceWarning`** — at present they're independent: adaptive can prevent the stall from happening; the warning still fires post-hoc if it didn't help. That seems right (no need to gate one on the other), but worth a paragraph in user docs eventually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
