### PR TITLE
Cap ridge_inverse bump loop; add NumericalWarning (#18)

### DIFF
--- a/src/manifoldgmm/_warnings.py
+++ b/src/manifoldgmm/_warnings.py
@@ -38,4 +38,24 @@ class ConvergenceWarning(UserWarning):
     """
 
 
-__all__ = ["ConvergenceWarning"]
+class NumericalWarning(UserWarning):
+    """A numerical operation completed in a degraded regime.
+
+    Emitted from low-level numerical helpers when an iterative procedure
+    bails out before reaching its target tolerance, returning a
+    best-effort result rather than continuing indefinitely.  Issue #18
+    is the motivating case: :func:`manifoldgmm.utils.numeric.ridge_inverse`
+    used to spin in a ``while True`` ridge-bump loop on severely
+    ill-conditioned matrices (``cond >> target_condition``); the loop
+    now caps and emits this warning instead.
+
+    Filter via the standard :mod:`warnings` interface, e.g.::
+
+        import warnings
+        from manifoldgmm import NumericalWarning
+
+        warnings.filterwarnings("ignore", category=NumericalWarning)
+    """
+
+
+__all__ = ["ConvergenceWarning", "NumericalWarning"]

--- a/src/manifoldgmm/econometrics/gmm.py
+++ b/src/manifoldgmm/econometrics/gmm.py
@@ -1027,7 +1027,19 @@ class GMMResult:
             because the first-order condition zeroes the score.
         ridge_condition : float, default 1e8
             Target condition number for matrix inversions via
-            :func:`~manifoldgmm.utils.numeric.ridge_inverse`.
+            :func:`~manifoldgmm.utils.numeric.ridge_inverse`.  On
+            severely ill-conditioned ``D'Omega^{-1}D``
+            (``cond >> ridge_condition``), ``ridge_inverse`` 's bump loop
+            saturates; it bails out under a cap (50 iterations by
+            default) and emits a
+            :class:`~manifoldgmm._warnings.NumericalWarning`, returning
+            a best-effort regularised inverse rather than hanging (the
+            historical behaviour reported in #18).  To short-circuit
+            the loop on a known ill-conditioned fit, inspect
+            :meth:`compute_hessian_cond` first and pass
+            ``ridge_condition`` above the empirical conditioning
+            (e.g. ``ridge_condition=1e12`` on a fit with
+            ``cond(D'WD) ~ 4e9``).
 
         Returns
         -------

--- a/src/manifoldgmm/utils/numeric.py
+++ b/src/manifoldgmm/utils/numeric.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import warnings
+
 import numpy as np
+
+from .._warnings import NumericalWarning
 
 
 def ridge_inverse(
@@ -10,34 +14,126 @@ def ridge_inverse(
     *,
     target_condition: float = 1e8,
     initial_ridge: float | None = None,
+    max_iterations: int = 50,
 ) -> tuple[np.ndarray, float]:
     """Return a stabilized inverse of a symmetric matrix.
 
-    The routine symmetrises ``matrix``, then iteratively adds a ridge ``λ I`` until
-    the estimated condition number falls below ``target_condition``. The final
-    inverse and ridge parameter are returned.
+    The routine symmetrises ``matrix``, then iteratively adds a ridge
+    :math:`\\lambda I` until the estimated condition number falls below
+    ``target_condition``.  The final inverse and ridge parameter are
+    returned.
+
+    Parameters
+    ----------
+    matrix:
+        Square matrix to invert.  Symmetrised internally.
+    target_condition:
+        Upper bound on the condition number of the (symmetrically
+        ridged) matrix before the inverse is computed.  Default ``1e8``.
+    initial_ridge:
+        Starting value of the ridge.  When ``None`` (default), starts
+        at ``0.0``.  Useful for warm-starting the loop on a previously
+        seen matrix.
+    max_iterations:
+        Hard cap on the number of bump-loop iterations before the
+        routine bails out and emits a :class:`~manifoldgmm._warnings.NumericalWarning`.
+        Default ``50`` -- well above the 2-3 iterations the formula
+        predicts on well-behaved inputs, and well below pathological
+        regimes that previously hung indefinitely (#18).  The cap is
+        only reached on inputs where no finite ridge brings the
+        condition under ``target_condition`` -- in that regime the
+        routine returns the inverse it has computed (forcing PD via a
+        final ridge bump if needed) with a warning naming the achieved
+        condition and final ridge.
+
+    Returns
+    -------
+    inv, ridge:
+        The ridge-regularised inverse and the ridge value that produced
+        it.  When the loop terminated normally, ``cond(matrix + ridge*I) <= target_condition``.
+        When the cap fired, the inverse is the best-effort result and
+        :class:`NumericalWarning` was emitted.
+
+    Notes
+    -----
+    For pathological matrices (``cond >> target_condition`` paired with
+    near-machine-epsilon spectral spread), callers can either
+    pre-compute an appropriate ``target_condition`` from
+    :meth:`manifoldgmm.GMMResult.compute_hessian_cond` and pass it
+    explicitly, or set ``warnings.filterwarnings("error", category=NumericalWarning)``
+    to escalate the cap-hit into an exception.  Issue #18 has further
+    discussion of the regime where this matters and the workarounds.
     """
 
     if (
         matrix.ndim != 2 or matrix.shape[0] != matrix.shape[1]
     ):  # pragma: no cover - sanity
         raise ValueError("matrix must be square")
+    if max_iterations < 1:
+        raise ValueError("max_iterations must be at least 1")
 
     sym = 0.5 * (matrix + matrix.T)
     ridge = initial_ridge if initial_ridge is not None else 0.0
 
-    while True:
+    last_max_eig = 0.0
+    last_min_eig = 0.0
+    last_condition = float("inf")
+    augmented = sym  # placeholder; overwritten in the loop
+    for _ in range(max_iterations):
         augmented = sym + ridge * np.eye(sym.shape[0], dtype=sym.dtype)
         eigvals = np.linalg.eigvalsh(augmented)
-        max_eig = float(np.max(eigvals))
-        min_eig = float(np.min(eigvals))
-        if min_eig <= 0.0:
+        last_max_eig = float(np.max(eigvals))
+        last_min_eig = float(np.min(eigvals))
+        if last_min_eig <= 0.0:
             ridge = max(ridge * 2.0, 1e-12 if ridge == 0.0 else ridge)
+            last_condition = float("inf")
             continue
-        condition = max_eig / min_eig
-        if condition <= target_condition:
+        last_condition = last_max_eig / last_min_eig
+        if last_condition <= target_condition:
             inv = np.linalg.inv(augmented)
             return inv, ridge
         # Increase ridge to hit the target condition roughly.
-        desired_min = max_eig / target_condition
-        ridge = max(ridge, desired_min - min_eig)
+        desired_min = last_max_eig / target_condition
+        new_ridge = max(ridge, desired_min - last_min_eig)
+        # Guard against the formula not strictly increasing ridge in
+        # near-singular regimes (the historical hang in #18): when the
+        # rule fails to move the ridge, fall back to a multiplicative
+        # bump so subsequent iterations make progress before the cap.
+        if new_ridge <= ridge:
+            new_ridge = ridge * 2.0 if ridge > 0.0 else max(1e-12, last_max_eig * 1e-12)
+        ridge = new_ridge
+
+    # Cap reached.  The loop body updated ``ridge`` past the last
+    # evaluated ``augmented``; rebuild ``augmented`` from the current
+    # ``ridge`` so the returned ``(inv, ridge)`` pair is self-consistent.
+    augmented = sym + ridge * np.eye(sym.shape[0], dtype=sym.dtype)
+    eigvals = np.linalg.eigvalsh(augmented)
+    last_max_eig = float(np.max(eigvals))
+    last_min_eig = float(np.min(eigvals))
+    last_condition = last_max_eig / last_min_eig if last_min_eig > 0.0 else float("inf")
+    # Force a positive-definite augmented matrix (the indefinite branch
+    # may have left us with a non-PD slice) before inverting.
+    if last_min_eig <= 0.0:
+        safety = max(abs(last_min_eig), last_max_eig * 1e-12, 1e-300)
+        ridge = ridge + safety * 2.0
+        augmented = sym + ridge * np.eye(sym.shape[0], dtype=sym.dtype)
+        eigvals = np.linalg.eigvalsh(augmented)
+        last_max_eig = float(np.max(eigvals))
+        last_min_eig = float(np.min(eigvals))
+        last_condition = (
+            last_max_eig / last_min_eig if last_min_eig > 0.0 else float("inf")
+        )
+    inv = np.linalg.inv(augmented)
+    warnings.warn(
+        (
+            f"ridge_inverse hit max_iterations={max_iterations} without "
+            f"reducing condition below target_condition={target_condition:.3g}; "
+            f"returning best-effort inverse with achieved "
+            f"condition={last_condition:.3g}, ridge={ridge:.3g}.  Caller may "
+            "pass a larger target_condition to short-circuit the bump loop, or "
+            "treat the regime as 'no asymptotic distribution available' (#18)."
+        ),
+        NumericalWarning,
+        stacklevel=2,
+    )
+    return inv, ridge

--- a/tests/utils/test_ridge_inverse.py
+++ b/tests/utils/test_ridge_inverse.py
@@ -1,0 +1,165 @@
+"""Tests for ``manifoldgmm.utils.numeric.ridge_inverse``.
+
+#18 motivated by ``k_statistic`` hanging in a non-terminating ridge-bump
+loop on severely ill-conditioned ``D'Omega^{-1}D``.  This module exercises
+the loop cap (default ``max_iterations=50``) and the
+:class:`NumericalWarning` it emits.  The well-conditioned path is also
+covered to ensure the cap is invisible there.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pytest
+from manifoldgmm._warnings import NumericalWarning
+from manifoldgmm.utils.numeric import ridge_inverse
+
+
+# ---------------------------------------------------------------------------
+# Well-conditioned: no ridge needed, no warning, identity-like behaviour
+# ---------------------------------------------------------------------------
+def test_well_conditioned_returns_unridged_inverse() -> None:
+    """``cond(matrix) < target_condition``: ridge stays at 0; inverse is exact."""
+
+    matrix = np.array([[2.0, 0.5], [0.5, 1.0]])
+    expected = np.linalg.inv(matrix)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", NumericalWarning)
+        inv, ridge = ridge_inverse(matrix, target_condition=1e8)
+
+    assert ridge == 0.0
+    assert np.allclose(inv, expected, atol=1e-12)
+
+
+def test_mildly_ill_conditioned_engages_ridge_without_warning() -> None:
+    """``cond > target_condition``: ridge engages, loop converges in a couple iters."""
+
+    # cond ~ 1e6: large but well within the ridge formula's reach.
+    matrix = np.diag([1.0, 1e-6])
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", NumericalWarning)
+        inv, ridge = ridge_inverse(matrix, target_condition=1e3)
+
+    augmented = matrix + ridge * np.eye(2)
+    cond_after = np.linalg.cond(augmented)
+    assert cond_after <= 1e3 * 1.0001  # small slack for floating-point round-trip
+    # ``inv`` is the actual inverse of the augmented matrix, not the original.
+    assert np.allclose(inv @ augmented, np.eye(2), atol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# Severely ill-conditioned: cap fires, warning emitted, best-effort inverse
+# ---------------------------------------------------------------------------
+def test_machine_eps_singular_hits_cap_with_warning() -> None:
+    """``cond ~ 1e16`` and small ``target_condition``: cap fires after exhausting bumps.
+
+    We construct a matrix whose smallest eigenvalue is near machine
+    epsilon relative to the largest; with ``target_condition=1e2`` the
+    ridge formula has no finite ridge that brings the conditioning that
+    low (because the spectral spread vs. ridge magnitude saturates), so
+    the cap fires.
+    """
+
+    matrix = np.diag([1.0, 1e-16])
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", NumericalWarning)
+        inv, ridge = ridge_inverse(matrix, target_condition=1.001, max_iterations=10)
+
+    relevant = [w for w in caught if issubclass(w.category, NumericalWarning)]
+    assert len(relevant) == 1, (
+        f"Expected exactly one NumericalWarning; got {len(relevant)}: "
+        f"{[str(w.message) for w in relevant]}"
+    )
+    msg = str(relevant[0].message)
+    assert "max_iterations=10" in msg
+    assert "target_condition" in msg
+    assert "best-effort inverse" in msg
+
+    # The returned inverse should be finite and approximately satisfy
+    # ``inv @ (matrix + ridge*I) = I`` to numerical tolerance.
+    assert np.all(np.isfinite(inv))
+    augmented = matrix + ridge * np.eye(2)
+    assert np.allclose(inv @ augmented, np.eye(2), atol=1e-8)
+
+
+def test_indefinite_matrix_terminates_under_cap() -> None:
+    """Negative-eigenvalue branch caps cleanly instead of doubling forever.
+
+    Pre-fix, an indefinite input with ``eigvalsh`` returning a slightly
+    negative eigenvalue would feed the ``min_eig <= 0`` branch which
+    doubles ridge.  If the ridge formula then fails to recover a
+    positive minimum eigenvalue under the target conditioning, the loop
+    would not terminate.  We don't need to reproduce that exactly --
+    we just need to confirm that with a low ``max_iterations`` and an
+    indefinite input, the routine terminates with a finite PD inverse
+    and a warning.
+    """
+
+    matrix = np.diag([1.0, -1e-3, 2.0])  # indefinite
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", NumericalWarning)
+        inv, ridge = ridge_inverse(matrix, target_condition=1.0001, max_iterations=5)
+
+    # At target_condition ~ 1.0 no finite ridge will hit the target on
+    # this design, so the cap should fire.
+    relevant = [w for w in caught if issubclass(w.category, NumericalWarning)]
+    assert len(relevant) >= 1
+    # Final ridge made the matrix PD; inverse is finite and correct.
+    assert np.all(np.isfinite(inv))
+    augmented = matrix + ridge * np.eye(3)
+    eigvals = np.linalg.eigvalsh(augmented)
+    assert (
+        eigvals.min() > 0.0
+    ), f"Augmented matrix should be PD after cap; eigvals={eigvals!r}"
+    assert np.allclose(inv @ augmented, np.eye(3), atol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Short-circuit workaround documented in k_statistic docstring + #18
+# ---------------------------------------------------------------------------
+def test_short_circuit_with_larger_target_condition_skips_warning() -> None:
+    """Passing ``target_condition`` above the actual cond returns immediately.
+
+    This is the workaround the ``k_statistic`` docstring points at:
+    when the caller has measured ``compute_hessian_cond()`` and knows
+    the matrix is ill-conditioned beyond a useful regulariser, they
+    can short-circuit the bump loop by setting a generous target.
+    """
+
+    matrix = np.diag([1.0, 1e-12])  # cond ~ 1e12
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", NumericalWarning)
+        inv, ridge = ridge_inverse(matrix, target_condition=1e14)
+
+    # With a generous target, the unridged matrix satisfies the
+    # condition criterion on iter 1 and the loop returns the raw
+    # inverse with ridge == 0.
+    assert ridge == 0.0
+    assert np.allclose(inv @ matrix, np.eye(2), atol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+def test_rejects_max_iterations_below_one() -> None:
+    """``max_iterations < 1`` raises ``ValueError``."""
+
+    with pytest.raises(ValueError, match="max_iterations"):
+        ridge_inverse(np.eye(2), max_iterations=0)
+
+
+def test_backward_compatible_signature() -> None:
+    """Existing callers (no ``max_iterations`` kwarg) keep working."""
+
+    matrix = np.array([[3.0, 0.0], [0.0, 1.0]])
+    # Same call shape as the existing callsites in econometrics/gmm.py
+    inv, ridge = ridge_inverse(matrix, target_condition=1e8)
+    assert ridge == 0.0
+    assert np.allclose(inv @ matrix, np.eye(2), atol=1e-12)


### PR DESCRIPTION
## Summary

Closes #18.  `ridge_inverse` historically spun in a `while True` bump loop on severely ill-conditioned inputs, causing `k_statistic` to hang at 100% CPU for >10 minutes on cluster-omega pickles with `cond(D'WD) ~ 4e9` (K-Aggregators K=1 het-exp) and `cond ~ 1e16` (any K=2 fit).  The first inversion (Omega_hat itself) completed fine; the second blew up because no finite ridge in the formula's recurrence brought `cond` below the default `target_condition=1e8`.

## What ships

| Surface | Detail |
|---------|--------|
| `ridge_inverse(..., max_iterations=50)` | Caps the bump loop.  When fired, recomputes `augmented` against the final ridge so the returned `(inv, ridge)` pair is self-consistent, forces PD if the indefinite branch left a non-PD slice, emits `NumericalWarning` naming the achieved cond + ridge value. |
| `NumericalWarning` | New canonical category in `manifoldgmm._warnings` (the placeholder listed alongside `ConvergenceWarning` in `CLAUDE.md` is now real).  Filterable via the standard `warnings` interface. |
| `k_statistic` docstring | Documents the cap behaviour and points callers at the `ridge_condition` short-circuit (pre-measure via `compute_hessian_cond()`, pass a generous target). |
| Defensive monotonicity guard | When the ridge-update formula fails to strictly increase `ridge` (the precise pathology that caused the original hang under certain spectral-spread regimes), fall back to a multiplicative bump so subsequent iterations make progress before the cap. |

## Tests (7 new, `tests/utils/test_ridge_inverse.py`)

- [x] Well-conditioned fit returns unridged inverse, no warning.
- [x] Mildly ill-conditioned fit engages ridge, converges in a couple iters, no warning.
- [x] `cond ~ 1e16` with tight `target_condition` hits cap with exactly one `NumericalWarning`; returned inverse is finite and satisfies `inv @ (matrix + ridge*I) == I` to numerical tolerance.
- [x] Indefinite-input case terminates with a PD augmented matrix and a warning instead of doubling ridge forever.
- [x] Short-circuit workaround: large `target_condition` accepts the raw matrix's conditioning, returns immediately with `ridge=0`, no warning.  This is the K-Aggregators caller-side recipe.
- [x] `max_iterations < 1` raises `ValueError`.
- [x] Signature backward compatibility: existing callsites (no `max_iterations` kwarg) keep working unchanged.

## Verification gates

- `make quick-check`: ruff + black + mypy clean, **160 passed, 1 skipped** (+7 new ridge_inverse tests vs. main's 153).
- `tests/econometrics/test_k_statistic.py` (slow MC, module-level `pytestmark = pytest.mark.slow`): all 6 tests pass in 250s.  Confirms the existing K-statistic Monte Carlo coverage on well-conditioned designs is unaffected.
- `gitnexus_detect_changes`: **MEDIUM** risk (touches `in_confidence_region` and `summary` execution flows via `ridge_inverse`).  Below the HIGH/CRITICAL threshold that requires user warning per CLAUDE.md.  Existing callers see no behaviour change unless their input previously hung -- the new code path is gated by hitting `max_iterations`, which requires `cond >> target_condition`.

## Relationship to other open work

- Independent of **PR #22** (#19 MR1 -- parameter-penalty hook).  Both branched off `main`; they don't overlap.
- **#21** (K-statistic decomposition under penalty) remains deferred regardless of this PR.  The current PR fixes the hang on unregularized fits; under-`penalty` fits still raise `NotImplementedError` from PR #22.
- After this lands, K-Aggregators callers can `k_statistic(ridge_condition=1e12)` (or higher) on the K=1 het-exp pickle and expect a finite K, S rather than a hang.

## Test plan

- [x] `make quick-check` green locally.
- [x] Slow `test_k_statistic.py` tests green locally.
- [ ] CI green on this branch.
- [ ] K-Aggregators side smokes `k_statistic` against the K=1 het-exp pickle with `ridge_condition=1e12` and confirms K, S return finite within seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)