### PR TITLE
Document penalty / cue_ridge composability (closes #19)

### DIFF
--- a/src/manifoldgmm/econometrics/gmm.py
+++ b/src/manifoldgmm/econometrics/gmm.py
@@ -158,6 +158,18 @@ class CUEWeighting:
         cond(Ω + ridge·I) ≤ target_condition. This handles cases where
         Ω(θ) becomes ill-conditioned as θ moves through the parameter space.
         The effective ridge is max(ridge, adaptive_ridge).
+
+    Notes
+    -----
+    ``ridge`` / ``target_condition`` regularise the *weighting matrix*
+    ``Ω̂(θ)``.  An independent parameter-space regulariser is available
+    on :class:`GMM` via the ``penalty`` keyword (since #19 MR1) -- see
+    :class:`PenaltyStrategy`.  The two knobs stack arithmetically but
+    firing both non-trivially is usually a sign that one of them should
+    be off: the weighting ridge addresses ``Ω̂`` conditioning, while
+    ``penalty`` addresses identification weakness in ``θ`` itself.
+    Basin-shifting consequences of an adaptive weighting ridge in
+    particular are discussed in #16.
     """
 
     def __init__(
@@ -313,6 +325,28 @@ class PenaltyStrategy(Protocol):
     is a *cost addition*, not a moment -- it leaves :math:`\\hat\\Omega`
     and the data Jacobian untouched and composes naturally with every
     :class:`WeightingStrategy`.  See #19 for the motivating discussion.
+
+    Composability with the CUE weighting ridge
+    ------------------------------------------
+    :class:`GMM` accepts ``cue_ridge`` / ``cue_target_condition`` (the
+    ridge on :math:`\\hat\\Omega` used by :class:`CUEWeighting`) and
+    ``penalty`` as **independent** regularisation knobs.  They stack
+    arithmetically -- nothing in the framework prevents firing both at
+    once -- but firing both non-trivially is usually a sign that one of
+    them should be off:
+
+    - ``penalty`` regularises the *parameters*; the right tool when
+      :math:`\\hat\\theta` is poorly identified (the criterion is flat
+      along some direction of the parameter space).  Moves the
+      stationary point.
+    - ``cue_ridge`` / ``cue_target_condition`` regularise the
+      *weighting matrix*; the right tool when :math:`\\hat\\Omega(\\theta)`
+      is poorly conditioned at the iterate.  Does not move the
+      stationary point unless the ridge is adaptive (i.e.,
+      :math:`\\lambda(\\theta)`).
+
+    The basin-shifting consequences of stacking an adaptive CUE ridge
+    in particular are discussed in #16.
 
     Optional methods, looked up via :func:`hasattr` at compute time:
 


### PR DESCRIPTION
## Summary

Closes #19.  #19's MR1 scope section promised *"Docstring + a paragraph in `weighting_info` will note the redundancy"* of the parameter penalty and the CUEWeighting ridge.  PR #22 (MR1) shipped everything else from that scope but missed this docstring polish.

## What ships

Two symmetric cross-references in `src/manifoldgmm/econometrics/gmm.py`:

1. A **"Composability with the CUE weighting ridge"** section on `PenaltyStrategy`'s Protocol docstring, explaining that `penalty` and `cue_ridge` / `cue_target_condition` are independent regularisation knobs that stack arithmetically, that firing both non-trivially is usually a sign one should be off, and that the basin-shifting consequences of the CUE-side adaptive ridge are tracked in #16.
2. A symmetric **"Notes"** paragraph on `CUEWeighting`'s docstring pointing back at `GMM(penalty=...)` with the same framing.

Cross-reference works in either direction:
- A user reading `PenaltyStrategy` sees that `cue_ridge` is a sibling knob.
- A user reading `CUEWeighting` sees that `penalty` is a sibling knob.

No code changes.  No new tests (this is documentation only on existing surfaces).

## Verification

- `make quick-check`: ruff + black + mypy clean, **170 passed, 1 skipped** (unchanged from post-merge `main`).

## What's left after this lands

Nothing strictly required for `#19`.  The remaining items I noted while triaging what's needed to close are:

- **K-Aggregators production demo** — soft, validates MR1 on the workload that motivated it.  Tracked downstream, not on `ManifoldGMM`'s side.
- **`tangent_basis` extension to `PenaltyStrategy`** — listed in #19's scope as "decide during MR1 review, not a blocker."  Nobody asked for it.  Left as documented open point; can be filed as a separate enhancement issue if a non-Euclidean parameter penalty becomes a real need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)