### PR TITLE
Narrow k_statistic guard to theta_0=None case (#21 narrowed; refs #25)

### DIFF
--- a/src/manifoldgmm/econometrics/gmm.py
+++ b/src/manifoldgmm/econometrics/gmm.py
@@ -1268,6 +1268,16 @@ class GMMResult:
             ``None`` (default), the estimator :math:`\hat\theta` is used;
             note that K evaluated at the estimator is typically near zero
             because the first-order condition zeroes the score.
+
+            On a penalised fit (``self.penalty is not None``) ``theta_0``
+            **must** be passed explicitly.  ``K(theta_0)`` for a
+            user-specified ``theta_0`` is a pure function of
+            ``(restriction, theta_0, data)`` -- it does not reference
+            the optimiser or the penalty -- so it remains valid under
+            penalty with the same asymptotic :math:`\chi^2(p)` reference
+            distribution.  ``K`` at the penalised estimator itself
+            (``theta_0=None`` defaulting to ``theta_hat_pen``) is a
+            different and not-yet-defined object; see #21.
         ridge_condition : float, default 1e8
             Target condition number for matrix inversions via
             :func:`~manifoldgmm.utils.numeric.ridge_inverse`.  On
@@ -1294,14 +1304,22 @@ class GMMResult:
         Assuming that They Are Identified." *Econometrica*, 73(4),
         1103--1123.
         """
-        if self.penalty is not None:
+        if self.penalty is not None and theta_0 is None:
             raise NotImplementedError(
-                "k_statistic is not yet defined under penalty != None; the "
-                "penalized score and information matrix shift the K/S "
-                "decomposition's reference distribution in a non-trivial "
-                "way.  See issue #21 for the deferred derivation; for now, "
-                "either drop the penalty or refit without it for "
-                "overidentification testing."
+                "k_statistic without an explicit ``theta_0`` defaults to "
+                "evaluating at theta_hat; on a penalised fit theta_hat is "
+                "theta_hat_pen, and K at theta_hat_pen is not yet defined "
+                "(the penalised FOC includes a (1/2) grad(p) term that "
+                "shifts the K decomposition's reference distribution).  "
+                "Pass ``theta_0`` explicitly to test a specific null "
+                "-- K(theta_0) is mathematically identical to the "
+                "unpenalised case and works under penalty, since the "
+                "formula is a pure function of (restriction, theta_0, data) "
+                "and does not reference the optimiser or penalty.  See "
+                "issue #21 for the deferred K(theta_hat_pen) derivation, "
+                "and #25 for the bootstrap K-statistic that addresses "
+                "finite-sample and cluster-aware testing under penalty "
+                "without further derivation work."
             )
         from scipy.stats import chi2 as chi2_dist
 

--- a/tests/econometrics/test_penalty.py
+++ b/tests/econometrics/test_penalty.py
@@ -369,10 +369,17 @@ def test_penalised_gmm_result_pickle_roundtrip(tmp_path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Deferred -- k_statistic guard (#21)
+# k_statistic guard (#21 narrowed, #25 file for finite-sample variant)
 # ---------------------------------------------------------------------------
-def test_k_statistic_raises_under_penalty() -> None:
-    """``GMMResult.k_statistic`` errors clearly when a penalty is active."""
+def test_k_statistic_raises_at_theta_hat_under_penalty() -> None:
+    """Default ``theta_0=None`` on a penalised fit raises pointing at #21.
+
+    The penalised FOC includes a (1/2) grad(p) term, so ``K`` at
+    ``theta_hat_pen`` is not the unpenalised K-statistic and has no
+    yet-defined reference distribution.  The guard fires on this path
+    and the error message tells the caller how to recover (pass
+    ``theta_0`` explicitly) plus where the deferred derivation lives.
+    """
 
     restriction = _mean_restriction()
     gmm = GMM(
@@ -385,8 +392,103 @@ def test_k_statistic_raises_under_penalty() -> None:
         optimizer_kwargs={"min_gradient_norm": 1e-12, "max_iterations": 500}
     )
 
-    with pytest.raises(NotImplementedError, match=r"#21"):
+    with pytest.raises(NotImplementedError) as excinfo:
         result.k_statistic()
+    msg = str(excinfo.value)
+    assert "#21" in msg, "guard message should point at the deferred derivation"
+    assert "theta_0" in msg, "guard message should tell the caller how to recover"
+
+
+def test_k_statistic_with_explicit_theta_0_works_under_penalty() -> None:
+    """``k_statistic(theta_0=...)`` is callable on a penalised fit.
+
+    ``K(theta_0)`` is a pure function of ``(restriction, theta_0,
+    data)`` -- it does not reference the optimiser or the penalty -- so
+    it remains valid under penalty.  The guard relaxation lets callers
+    test a specific null on a penalised ``GMMResult`` without
+    refitting.
+    """
+
+    restriction = _mean_restriction()
+    gmm = GMM(
+        restriction,
+        weighting=FixedWeighting(np.eye(1)),
+        initial_point=jnp.array([0.0]),
+        penalty=lambda theta: 0.5 * theta[0] ** 2,
+    )
+    result = gmm.estimate(
+        optimizer_kwargs={"min_gradient_norm": 1e-12, "max_iterations": 500}
+    )
+
+    # Pick a theta_0 distinct from both ybar (= 2.5) and theta_hat_pen
+    # (= N ybar / (N + lambda) = 4 * 2.5 / 4.5 = 2.222...) so K is
+    # comfortably non-trivial.
+    ks = result.k_statistic(theta_0=jnp.array([3.0]))
+
+    # All four returned values are finite scalars; degrees of freedom
+    # are the expected p == ell == 1 for the mean fixture.
+    assert np.isfinite(ks.K)
+    assert np.isfinite(ks.S)
+    assert np.isfinite(ks.J)
+    assert ks.df_K == 1
+    assert ks.df_S == 0  # ell - p = 1 - 1 = 0; over-id component degenerate
+    assert 0.0 <= ks.p_K <= 1.0
+
+
+def test_k_statistic_at_theta_0_is_penalty_invariant() -> None:
+    """Same restriction, same theta_0: K matches with and without penalty.
+
+    Demonstrates the insight that motivated the guard relaxation:
+    ``K(theta_0)`` depends only on the restriction, the null, and the
+    data -- not on whether the optimiser used a penalty.  Both fits
+    converge to different ``theta_hat`` (penalised vs unpenalised),
+    but ``k_statistic(theta_0=X)`` returns numerically identical
+    K, S, J, p_K, p_S in both cases.
+    """
+
+    restriction = _mean_restriction()
+    init = jnp.array([0.0])
+    theta_0 = jnp.array([3.0])
+
+    gmm_unpenalised = GMM(
+        restriction,
+        weighting=FixedWeighting(np.eye(1)),
+        initial_point=init,
+    )
+    gmm_penalised = GMM(
+        restriction,
+        weighting=FixedWeighting(np.eye(1)),
+        initial_point=init,
+        penalty=lambda theta: 0.5 * theta[0] ** 2,
+    )
+
+    res_un = gmm_unpenalised.estimate(
+        optimizer_kwargs={"min_gradient_norm": 1e-12, "max_iterations": 500}
+    )
+    res_pen = gmm_penalised.estimate(
+        optimizer_kwargs={"min_gradient_norm": 1e-12, "max_iterations": 500}
+    )
+
+    # Sanity: the two fits did land at different theta_hat, so we are
+    # really testing penalty-independence rather than measuring the
+    # same fit twice.
+    assert not np.allclose(
+        np.asarray(res_un.theta.value), np.asarray(res_pen.theta.value)
+    )
+
+    ks_un = res_un.k_statistic(theta_0=theta_0)
+    ks_pen = res_pen.k_statistic(theta_0=theta_0)
+
+    # K, S, J at the same theta_0 are numerically identical across
+    # the two fits -- they share the same restriction/data/null.
+    assert np.isclose(
+        ks_un.K, ks_pen.K, atol=1e-10
+    ), f"K mismatch: unpenalised={ks_un.K!r}, penalised={ks_pen.K!r}"
+    assert np.isclose(ks_un.S, ks_pen.S, atol=1e-10)
+    assert np.isclose(ks_un.J, ks_pen.J, atol=1e-10)
+    assert ks_un.df_K == ks_pen.df_K
+    assert ks_un.df_S == ks_pen.df_S
+    assert np.isclose(ks_un.p_K, ks_pen.p_K, atol=1e-10)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

MR1's `NotImplementedError` guard in PR #22 was too broad.  This PR relaxes it so callers can use `k_statistic(theta_0=...)` on a penalised `GMMResult`, and clarifies in the docstring + the (newly-narrowed) #21 that only the `theta_0=None` (K-at-theta_hat-pen) case remains genuinely deferred.

## The insight

`K(theta_0)` for a user-specified `theta_0` is a pure function of `(restriction, theta_0, data)`.  Every ingredient -- `g_bar(theta_0)`, `Omega_hat(theta_0)`, `D(theta_0)` -- is computed at the null point, not at the optimiser's landing point.  The penalty enters nowhere in the formula, and Kleibergen's asymptotic `chi^2(p)` result is a statement about the moment function and data under `H0: E[g_i(theta_0)] = 0` without reference to the optimiser.  So K(theta_0) at an explicit null is mathematically identical to the unpenalised case, both in formula and in asymptotic reference distribution.

Only K at `theta_hat_pen` (the default `theta_0=None` branch) depends on the penalty: the penalised FOC is `D'Wg + (1/2) grad(p) = 0`, not `D'Wg = 0`, so K at the penalised estimator picks up a non-zero contribution from the penalty score.  That genuinely-deferred derivation continues to live in #21.

## What ships

- Guard logic: fires only when `theta_0 is None AND penalty is not None` (the K-at-theta_hat-pen path).  Error message tells the caller how to recover (pass `theta_0` explicitly), points at #21 for the deferred derivation, and points at #25 for the bootstrap alternative.
- `k_statistic` docstring's `theta_0` Parameters block documents the new policy on penalised fits.
- Updates to `tests/econometrics/test_penalty.py`:
  - `test_k_statistic_raises_under_penalty` renamed to `test_k_statistic_raises_at_theta_hat_under_penalty` and tightened to verify the message mentions `theta_0` alongside #21.
  - **New** `test_k_statistic_with_explicit_theta_0_works_under_penalty`: direct exercise of the relaxed path on a penalised fit; verifies finite K, S, J, p_K with the expected degrees of freedom on the mean fixture.
  - **New** `test_k_statistic_at_theta_0_is_penalty_invariant`: same restriction, same `theta_0`, fits with and without penalty; asserts that the two landed at different `theta_hat` yet return numerically-identical K, S, J, p_K, p_S.  This is the cleanest demonstration of the insight.

## Verification gates

- `make quick-check`: ruff + black + mypy clean, **172 passed, 1 skipped** (+2 new tests; the existing guard test was rewritten rather than added to, so net +2).
- `gitnexus_detect_changes`: **LOW** risk -- additive guard relaxation, no execution flows affected.  Existing callers see no behaviour change unless they were previously hitting the `NotImplementedError`.

## Relationship to other open work

- **#21** body has been updated to clarify the narrower scope: this issue now tracks specifically `K(theta_hat_pen)` under penalty (the analytical derivation), not `K(theta_0)` for arbitrary `theta_0` (which is now callable directly).
- **#25** filed for the bootstrap K-statistic that handles finite-sample / cluster-aware testing.  Bootstrap is the practical alternative for both penalised and unpenalised fits where the asymptotic `chi^2(p)` is a thin approximation (small cluster count, ill-conditioned `D'Omega^{-1}D`).  This guard relaxation is the prerequisite for `k_statistic_bootstrap` to be callable on penalised fits.
- **PR #24** (docstring composability) is on `main` (or close to it).  No file-region conflict; either order works.

## Test plan

- [x] `make quick-check` green locally.
- [ ] CI green on this branch (expect the usual ~30-45 min window per the CI prior I established last time).
- [ ] K-Aggregators side calls `result.k_statistic(theta_0=...)` on a penalised pickle and verifies finite K, S, p_K return (real-world unblock of the explicit-theta_0 workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)