### PR TITLE
Add bootstrap K-statistic (#25)

### DIFF
--- a/src/manifoldgmm/econometrics/bootstrap.py
+++ b/src/manifoldgmm/econometrics/bootstrap.py
@@ -153,6 +153,37 @@ def exponential_weights(n: int, rng: np.random.Generator) -> np.ndarray:
     return rng.exponential(scale=1.0, size=n)
 
 
+def rademacher_signs(n: int, rng: np.random.Generator) -> np.ndarray:
+    r"""Pure :math:`\pm 1` Rademacher signs.
+
+    Distinct from :func:`rademacher_weights` (which returns shifted
+    weights in :math:`\{0, 2\}` for the fit-replication bootstrap);
+    these are the mean-zero sign-flip weights used by the wild
+    bootstrap of *centred* moment contributions.  Used by
+    :func:`k_statistic_bootstrap_for_result` when testing
+    ``H0: theta = theta_0`` -- the centred g_i have approximately mean
+    zero under H0, so multiplying by mean-zero signs yields a
+    bootstrap whose g_bar* is approximately mean zero too.
+
+    Statistical properties: :math:`E[s] = 0`, :math:`\operatorname{Var}[s] = 1`,
+    :math:`s^2 = 1` always.
+
+    Parameters
+    ----------
+    n : int
+        Number of signs to draw.
+    rng : numpy.random.Generator
+        Seeded random number generator.
+
+    Returns
+    -------
+    numpy.ndarray
+        Shape ``(n,)`` with values in ``{-1.0, +1.0}``.
+    """
+
+    return (2 * rng.integers(0, 2, size=n) - 1).astype(float)
+
+
 _WEIGHT_GENERATORS: dict[str, Callable[[int, np.random.Generator], np.ndarray]] = {
     "rademacher": rademacher_weights,
     "mammen": mammen_weights,
@@ -892,12 +923,282 @@ class MomentWildBootstrap:
         return info
 
 
+# -----------------------------------------------------------------------
+# Bootstrap K-statistic (#25)
+# -----------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class KStatBootstrapResult:
+    """Output of :func:`k_statistic_bootstrap_for_result`.
+
+    Attributes
+    ----------
+    K_observed, S_observed, J_observed:
+        Point estimates of K, S, J at ``theta_0`` computed on the data.
+        Match what :meth:`GMMResult.k_statistic` would return for the
+        same ``theta_0`` (the bootstrap doesn't change these; it only
+        produces a reference distribution against which to compare them).
+    K_bootstrap, S_bootstrap, J_bootstrap:
+        Arrays of bootstrap replicates of K*, S*, J* under H0:
+        ``theta = theta_0``.  Each has length ``n_replicates``.
+    df_K, df_S:
+        Degrees of freedom for the asymptotic chi^2 reference
+        distributions of K and S (``p`` and ``ell - p`` respectively,
+        matching :class:`KStatisticResult`).
+    p_K_bootstrap, p_S_bootstrap:
+        Percentile p-values from the bootstrap distributions:
+        ``(1 + sum(K_bootstrap >= K_observed)) / (1 + n_replicates)``
+        (the +1's give the conventional small-sample-corrected upper
+        bound on the p-value).
+    p_K_asymptotic, p_S_asymptotic:
+        Reference chi^2-based p-values from the same observed
+        statistics; reported alongside the bootstrap p-values so a
+        caller can inspect the gap between the two reference
+        distributions.
+    n_replicates:
+        Number of bootstrap replicates run.
+    method:
+        ``"iid"`` when no cluster structure was found, ``"cluster_wild"``
+        otherwise.
+    cluster_info:
+        ``{"num_clusters": G, "source": "argument" | "restriction"}``
+        when clustered; ``None`` when ``method == "iid"``.
+    """
+
+    K_observed: float
+    S_observed: float
+    J_observed: float
+    K_bootstrap: np.ndarray
+    S_bootstrap: np.ndarray
+    J_bootstrap: np.ndarray
+    df_K: int
+    df_S: int
+    p_K_bootstrap: float
+    p_S_bootstrap: float
+    p_K_asymptotic: float
+    p_S_asymptotic: float
+    n_replicates: int
+    method: str
+    cluster_info: Mapping[str, Any] | None
+
+
+def k_statistic_bootstrap_for_result(
+    result: GMMResult,
+    *,
+    theta_0: Any,
+    n_replicates: int = 200,
+    cluster_index: Any | None = None,
+    ridge_condition: float = 1e8,
+    rng: np.random.Generator | int | None = None,
+) -> KStatBootstrapResult:
+    r"""Cluster-wild bootstrap of the Kleibergen K-statistic at ``theta_0``.
+
+    See #25 for motivation and design.  Sketch:
+
+    1. Compute the per-observation moment matrix :math:`g_i(\theta_0)`
+       and centre it.
+    2. Compute the data-side ingredients (``Omega_hat``, ``D``,
+       ``Omega_hat^{-1}``, ``(D' Omega^{-1} D)^{-1}``) once; cache the
+       projection ``P = Omega^{-1} D (D' Omega^{-1} D)^{-1} D' Omega^{-1}``
+       so each replicate's :math:`K^* = g_bar^{*\top} P g_bar^*` is a
+       single quadratic form.
+    3. For each replicate, draw :math:`\pm 1` Rademacher signs (one per
+       cluster, broadcast to observations), compute weighted
+       :math:`g_bar^*`, and evaluate :math:`K^*`, :math:`J^*`,
+       :math:`S^* = J^* - K^*` using the cached projection.
+
+    Omega is held fixed at its sample value across replicates -- the
+    standard wild-bootstrap recipe for test statistics.  Recomputing
+    ``Omega^*`` per replicate would add Monte Carlo noise without
+    statistical gain; under :math:`\pm 1` Rademacher cluster signs
+    ``Omega^*`` (centred) is approximately equal to ``Omega`` anyway.
+
+    Penalty independence: ``K(theta_0)`` is a pure function of
+    ``(restriction, theta_0, data)`` and the bootstrap inherits this
+    property -- the function produces identical p-values on penalised
+    and unpenalised ``GMMResult`` instances fit on the same data.
+
+    Parameters
+    ----------
+    result:
+        The ``GMMResult`` whose restriction supplies the moment
+        function, cluster structure (if any), and tangent basis at
+        ``theta_0``.
+    theta_0:
+        Hypothesised parameter value under H0.  Required (no default);
+        the bootstrap of K at the estimator itself (``theta_0=None``)
+        would conflate with #21's open derivation.
+    n_replicates:
+        Number of bootstrap replicates.  Default 200, matching the
+        order of magnitude callers typically use for percentile
+        inference.
+    cluster_index:
+        Optional override for the cluster assignment.  When ``None``
+        (default), falls back to ``result.restriction.clusters``; if
+        that is also ``None``, the bootstrap is per-observation iid
+        (each observation gets its own sign).
+    ridge_condition:
+        Target condition number passed to
+        :func:`~manifoldgmm.utils.numeric.ridge_inverse` for the data-
+        side inversions.  See :meth:`GMMResult.k_statistic`'s
+        docstring for the ``cond >> ridge_condition`` workaround.
+    rng:
+        ``numpy.random.Generator``, integer seed, or ``None`` for a
+        fresh default RNG.
+
+    Returns
+    -------
+    KStatBootstrapResult
+
+    References
+    ----------
+    Kleibergen, F. (2005). "Testing Parameters in GMM Without
+    Assuming that They Are Identified." *Econometrica*, 73(4),
+    1103--1123.
+
+    Davidson, R. and Flachaire, E. (2008). "The wild bootstrap, tamed
+    at last." *Journal of Econometrics*, 146(1), 162--169.
+    """
+
+    from scipy.stats import chi2 as chi2_dist
+
+    from ..utils.numeric import ridge_inverse
+
+    restriction = result.restriction
+
+    # Resolve theta_0 to a ManifoldPoint matching the result's manifold.
+    if isinstance(theta_0, ManifoldPoint):
+        eval_point: ManifoldPoint = theta_0
+    else:
+        eval_point = ManifoldPoint(result._theta.manifold, theta_0)
+
+    # 1. Per-observation moment matrix at theta_0; shape (N, ell).
+    # ``moment_contributions`` returns a 1-D array of length N when ``ell == 1``;
+    # promote to (N, 1) so downstream matmul indexing is uniform.
+    g_matrix = np.asarray(restriction.moment_contributions(eval_point), dtype=float)
+    if g_matrix.ndim == 1:
+        g_matrix = g_matrix.reshape(-1, 1)
+    if g_matrix.ndim != 2:
+        raise ValueError(
+            "moment_contributions must return a 1-D (length N, ell==1) or "
+            f"2-D (N, ell) matrix; got shape {g_matrix.shape!r}."
+        )
+    N, ell = g_matrix.shape
+
+    # 2. Cluster structure: explicit override > restriction.clusters > iid.
+    if cluster_index is not None:
+        labels = np.asarray(cluster_index)
+        if labels.ndim != 1:
+            labels = labels.reshape(-1)
+        if labels.size != N:
+            raise ValueError(
+                f"cluster_index has {labels.size} entries; expected {N} "
+                "(one per observation)."
+            )
+        _, codes = np.unique(labels, return_inverse=True)
+        codes = np.asarray(codes, dtype=np.int64)
+        G = int(codes.max() + 1) if codes.size > 0 else 0
+        cluster_source = "argument"
+    elif restriction.clusters is not None:
+        codes, G = restriction._resolve_cluster_codes(N)
+        cluster_source = "restriction"
+    else:
+        codes = np.arange(N, dtype=np.int64)
+        G = N
+        cluster_source = None
+
+    method = "iid" if cluster_source is None else "cluster_wild"
+    cluster_info: Mapping[str, Any] | None = (
+        None
+        if cluster_source is None
+        else {"num_clusters": G, "source": cluster_source}
+    )
+
+    # 3. g_bar and centred contributions.  g_bar = (1/sqrt(N)) sum g_i;
+    # individual contributions are centred by subtracting mean(g_i)
+    # = g_bar / sqrt(N).
+    sqrt_N = float(N) ** 0.5
+    g_mean = g_matrix.mean(axis=0)  # shape (ell,)
+    g_bar = sqrt_N * g_mean  # matches MomentRestriction.g_bar convention
+    g_centered = g_matrix - g_mean  # shape (N, ell)
+
+    # 4. Data-side ingredients at theta_0.  Use cached Jacobian when
+    # eval_point is result._theta; recompute fresh otherwise (mirrors
+    # ``k_statistic``'s caching logic).
+    if eval_point is result._theta:
+        D = result.canonical_jacobian()
+    else:
+        basis = restriction.tangent_basis(eval_point)
+        D = restriction.jacobian_matrix(eval_point, basis=basis)
+    D = np.asarray(D, dtype=float)
+
+    omega = np.asarray(restriction.omega_hat(eval_point), dtype=float)
+    omega_inv, _ = ridge_inverse(omega, target_condition=ridge_condition)
+    DtW = D.T @ omega_inv  # (p, ell)
+    DtWD = DtW @ D
+    DtWD_inv, _ = ridge_inverse(DtWD, target_condition=ridge_condition)
+    P = DtW.T @ DtWD_inv @ DtW  # (ell, ell); projection under Omega^{-1}
+
+    # 5. Observed statistics at theta_0.
+    K_observed = float(g_bar @ P @ g_bar)
+    J_observed = float(g_bar @ omega_inv @ g_bar)
+    S_observed = max(J_observed - K_observed, 0.0)
+    p = D.shape[1]
+    df_K = p
+    df_S = max(ell - p, 0)
+
+    # 6. Bootstrap loop, vectorised over replicates.
+    rng_ = np.random.default_rng(rng)
+    # Cluster signs: shape (n_replicates, G); broadcast to (n_replicates, N).
+    cluster_signs = (2 * rng_.integers(0, 2, size=(n_replicates, G)) - 1).astype(float)
+    weights = cluster_signs[:, codes]  # (n_replicates, N)
+    # gbar_star[b, k] = (1/sqrt(N)) sum_i weights[b, i] * g_centered[i, k]
+    gbar_star = (weights @ g_centered) / sqrt_N  # (n_replicates, ell)
+    K_bootstrap = np.einsum("bi,ij,bj->b", gbar_star, P, gbar_star)
+    J_bootstrap = np.einsum("bi,ij,bj->b", gbar_star, omega_inv, gbar_star)
+    S_bootstrap = np.maximum(J_bootstrap - K_bootstrap, 0.0)
+
+    # 7. p-values.  Bootstrap: small-sample-corrected percentile
+    # ``(1 + #{K* >= K_obs}) / (1 + n_replicates)``.  Asymptotic:
+    # chi^2 survival from the same observed statistic.
+    p_K_boot = float((1 + np.sum(K_bootstrap >= K_observed)) / (1 + n_replicates))
+    p_S_boot = float((1 + np.sum(S_bootstrap >= S_observed)) / (1 + n_replicates))
+    p_K_asy = (
+        float(1.0 - chi2_dist.cdf(K_observed, df=df_K)) if df_K > 0 else float("nan")
+    )
+    p_S_asy = (
+        float(1.0 - chi2_dist.cdf(S_observed, df=df_S)) if df_S > 0 else float("nan")
+    )
+
+    return KStatBootstrapResult(
+        K_observed=K_observed,
+        S_observed=S_observed,
+        J_observed=J_observed,
+        K_bootstrap=K_bootstrap,
+        S_bootstrap=S_bootstrap,
+        J_bootstrap=J_bootstrap,
+        df_K=df_K,
+        df_S=df_S,
+        p_K_bootstrap=p_K_boot,
+        p_S_bootstrap=p_S_boot,
+        p_K_asymptotic=p_K_asy,
+        p_S_asymptotic=p_S_asy,
+        n_replicates=n_replicates,
+        method=method,
+        cluster_info=cluster_info,
+    )
+
+
 __all__ = [
     "MomentWildBootstrap",
     "BootstrapTask",
     "BootstrapResult",
+    "KStatBootstrapResult",
     "geodesic_mahalanobis_distance",
+    "k_statistic_bootstrap_for_result",
     "rademacher_weights",
+    "rademacher_signs",
     "mammen_weights",
     "exponential_weights",
 ]

--- a/src/manifoldgmm/econometrics/gmm.py
+++ b/src/manifoldgmm/econometrics/gmm.py
@@ -1387,6 +1387,79 @@ class GMMResult:
             p_S=p_S,
         )
 
+    def k_statistic_bootstrap(
+        self,
+        *,
+        theta_0: ManifoldPoint | Any,
+        n_replicates: int = 200,
+        cluster_index: Any | None = None,
+        ridge_condition: float = 1e8,
+        rng: Any = None,
+    ) -> Any:
+        r"""Cluster-wild bootstrap of the Kleibergen K-statistic at ``theta_0``.
+
+        Returns a :class:`~manifoldgmm.econometrics.bootstrap.KStatBootstrapResult`
+        carrying observed K, S, J at ``theta_0`` alongside bootstrap
+        reference distributions and both percentile (bootstrap) and
+        chi^2 (asymptotic) p-values.  See #25 for design discussion.
+
+        Compared to :meth:`k_statistic` (which exposes only the
+        asymptotic test), the bootstrap variant is useful when:
+
+        - The cluster count is small enough that the asymptotic
+          chi^2 reference is a thin approximation under clustering.
+        - ``D' Omega^{-1} D`` is severely ill-conditioned and
+          :func:`~manifoldgmm.utils.numeric.ridge_inverse` had to fire
+          its cap; the bootstrap implicitly captures the same
+          regularisation in the empirical reference distribution.
+        - Validation: comparing ``p_K_bootstrap`` and
+          ``p_K_asymptotic`` is a cheap sanity check on the asymptotic
+          result.
+
+        Penalty independence: like :meth:`k_statistic` with an explicit
+        ``theta_0``, the bootstrap is a pure function of
+        ``(restriction, theta_0, data)`` and produces identical p-values
+        on penalised and unpenalised ``GMMResult`` instances fit on the
+        same data.
+
+        Parameters
+        ----------
+        theta_0:
+            Hypothesised parameter value under H0.  Required (no
+            default); the bootstrap at the estimator itself
+            (``theta_0=None``) would conflate with #21's open
+            derivation under penalty.
+        n_replicates:
+            Number of bootstrap replicates.  Default 200.
+        cluster_index:
+            Optional override of cluster structure (length-N array of
+            cluster labels).  When ``None``, falls back to
+            ``self.restriction.clusters``; if that is also ``None``,
+            the bootstrap is per-observation iid.
+        ridge_condition:
+            Target condition number for the data-side
+            ``ridge_inverse`` calls.  See :meth:`k_statistic`'s
+            docstring for the workaround on severely ill-conditioned
+            ``D' Omega^{-1} D``.
+        rng:
+            ``numpy.random.Generator``, integer seed, or ``None``.
+
+        Returns
+        -------
+        KStatBootstrapResult
+        """
+
+        from .bootstrap import k_statistic_bootstrap_for_result
+
+        return k_statistic_bootstrap_for_result(
+            self,
+            theta_0=theta_0,
+            n_replicates=n_replicates,
+            cluster_index=cluster_index,
+            ridge_condition=ridge_condition,
+            rng=rng,
+        )
+
     def in_asymptotic_region(
         self, point: ManifoldPoint | Any, alpha: float = 0.05
     ) -> bool:

--- a/tests/econometrics/test_k_statistic_bootstrap.py
+++ b/tests/econometrics/test_k_statistic_bootstrap.py
@@ -1,0 +1,366 @@
+"""Tests for the bootstrap K-statistic (#25).
+
+Covers the six acceptance criteria filed against #25:
+
+1. Returns finite ``K_observed`` and arrays of the right length.
+2. On a well-conditioned synthetic fixture, bootstrap and asymptotic
+   p-values agree to within Monte Carlo error.
+3. On an ill-conditioned fixture where ``ridge_inverse`` fires its
+   cap, the bootstrap p-value is well-defined.
+4. Penalty independence: same numerical p-values on a penalised
+   ``GMMResult`` vs unpenalised ``GMMResult`` fit on the same data.
+5. Cluster-aware bootstrap with cluster size 1 reproduces the
+   iid variant (degenerate sanity check).
+6. Pickle round-trip on ``KStatBootstrapResult``.
+"""
+
+from __future__ import annotations
+
+import pickle
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from manifoldgmm import GMM, Manifold, MomentRestriction
+from manifoldgmm.econometrics.bootstrap import (
+    KStatBootstrapResult,
+    rademacher_signs,
+)
+from manifoldgmm.econometrics.gmm import FixedWeighting
+from pymanopt.manifolds import Euclidean as PymanoptEuclidean
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+def _well_conditioned_fit():
+    """``g_i(theta) = y_i - theta``, N=100, Euclidean(1).  cond(D'WD) ~ O(1)."""
+
+    rng = np.random.default_rng(20260523)
+    data = jnp.asarray(rng.standard_normal(size=100).astype(np.float64))
+
+    def gi_jax(theta, observation):
+        return observation - theta[0]
+
+    manifold = Manifold.from_pymanopt(PymanoptEuclidean(1))
+    restriction = MomentRestriction(
+        gi_jax=gi_jax,
+        data=data,
+        manifold=manifold,
+        backend="jax",
+        parameter_labels=["theta"],
+    )
+    gmm = GMM(
+        restriction,
+        weighting=FixedWeighting(np.eye(1)),
+        initial_point=jnp.array([0.0]),
+    )
+    return gmm.estimate(
+        optimizer_kwargs={"min_gradient_norm": 1e-12, "max_iterations": 500}
+    )
+
+
+# ---------------------------------------------------------------------------
+# rademacher_signs helper
+# ---------------------------------------------------------------------------
+def test_rademacher_signs_returns_pm_one() -> None:
+    """``rademacher_signs(n, rng)`` returns values in ``{-1, +1}``."""
+
+    rng = np.random.default_rng(1)
+    signs = rademacher_signs(1000, rng)
+    assert signs.shape == (1000,)
+    assert set(np.unique(signs).tolist()).issubset({-1.0, 1.0})
+    # Empirical mean ~ 0 for n=1000 with high probability
+    assert abs(signs.mean()) < 0.1
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion 1: returns finite, right shape
+# ---------------------------------------------------------------------------
+def test_bootstrap_returns_correct_shape_and_finite() -> None:
+    """Bootstrap returns finite ``K_observed`` and arrays of length ``n_replicates``."""
+
+    result = _well_conditioned_fit()
+
+    boot = result.k_statistic_bootstrap(
+        theta_0=jnp.array([0.5]), n_replicates=50, rng=42
+    )
+
+    assert isinstance(boot, KStatBootstrapResult)
+    assert np.isfinite(boot.K_observed)
+    assert np.isfinite(boot.J_observed)
+    assert boot.S_observed >= 0.0
+    assert boot.K_bootstrap.shape == (50,)
+    assert boot.J_bootstrap.shape == (50,)
+    assert boot.S_bootstrap.shape == (50,)
+    assert np.all(np.isfinite(boot.K_bootstrap))
+    assert np.all(np.isfinite(boot.J_bootstrap))
+    assert np.all(boot.S_bootstrap >= 0.0)
+    assert boot.df_K == 1
+    assert boot.df_S == 0  # ell - p == 1 - 1 == 0
+    assert 0.0 <= boot.p_K_bootstrap <= 1.0
+    assert boot.n_replicates == 50
+    assert boot.method == "iid"
+    assert boot.cluster_info is None
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion 2: bootstrap vs asymptotic agreement on
+# a well-conditioned fixture
+# ---------------------------------------------------------------------------
+def test_bootstrap_agrees_with_asymptotic_on_well_conditioned_fixture() -> None:
+    """``p_K_bootstrap`` and ``p_K_asymptotic`` agree within MC error on iid data.
+
+    With N=100 standard-normal data and a scalar mean model, the
+    K-statistic at ``theta_0 = 0.5`` (the truth here is ~0; ``theta_0``
+    is meaningfully off the data mean so K is non-trivial)
+    has a well-known chi^2(1) reference asymptotically.  With 500
+    bootstrap replicates the percentile p-value should land within
+    ~0.05 of the asymptotic p-value.
+    """
+
+    result = _well_conditioned_fit()
+    boot = result.k_statistic_bootstrap(
+        theta_0=jnp.array([0.5]), n_replicates=500, rng=20260523
+    )
+
+    # The two p-values should both be in (0, 1); their distance bounds
+    # Monte Carlo error of the bootstrap.
+    assert 0.0 < boot.p_K_asymptotic < 1.0
+    assert 0.0 < boot.p_K_bootstrap < 1.0
+    # On well-conditioned data the gap should be small.  Allow a
+    # generous 0.1 tolerance to keep the test robust to the rng seed.
+    assert abs(boot.p_K_bootstrap - boot.p_K_asymptotic) < 0.1, (
+        f"Bootstrap p_K={boot.p_K_bootstrap:.3f} differs from "
+        f"asymptotic p_K={boot.p_K_asymptotic:.3f} by more than 0.1; "
+        "either the bootstrap is misimplemented or the fixture is "
+        "ill-conditioned."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion 3: ill-conditioned regime returns well-defined p-value
+# ---------------------------------------------------------------------------
+def test_bootstrap_well_defined_when_ridge_inverse_fires_cap() -> None:
+    """Under-id design (rank-deficient D): bootstrap p-value still finite.
+
+    With ``g_i = y_i - (theta1 + theta2)`` and a 2-D Euclidean
+    parameter, ``D'WD`` is rank 1.  ``ridge_inverse`` will fire its
+    cap on the second inversion (``D' Omega^{-1} D``) with
+    ``ridge_condition`` smaller than the matrix's effective conditioning.
+    The bootstrap should still produce finite K, S statistics under
+    the warning regime.
+    """
+
+    rng = np.random.default_rng(20260523)
+    data = jnp.asarray(rng.standard_normal(size=80).astype(np.float64))
+
+    def gi_jax(theta, observation):
+        return observation - (theta[0] + theta[1])
+
+    manifold = Manifold.from_pymanopt(PymanoptEuclidean(2))
+    restriction = MomentRestriction(
+        gi_jax=gi_jax,
+        data=data,
+        manifold=manifold,
+        backend="jax",
+        parameter_labels=["theta1", "theta2"],
+    )
+    gmm = GMM(
+        restriction,
+        weighting=FixedWeighting(np.eye(1)),
+        initial_point=jnp.array([0.0, 0.0]),
+    )
+    result = gmm.estimate(
+        optimizer_kwargs={"min_gradient_norm": 1e-12, "max_iterations": 500}
+    )
+
+    # ``ridge_condition`` deliberately small (1e3) so ridge_inverse's
+    # cap fires on the rank-1 D'WD; the bootstrap should silently
+    # tolerate that and return finite stats.
+    boot = result.k_statistic_bootstrap(
+        theta_0=jnp.array([0.5, 0.5]),
+        n_replicates=100,
+        rng=42,
+        ridge_condition=1e3,
+    )
+
+    assert np.isfinite(boot.K_observed)
+    assert np.all(np.isfinite(boot.K_bootstrap))
+    assert 0.0 <= boot.p_K_bootstrap <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion 4: penalty independence
+# ---------------------------------------------------------------------------
+def test_bootstrap_is_penalty_invariant() -> None:
+    """Same restriction, same theta_0: bootstrap matches across penalty status.
+
+    With the same RNG seed, the bootstrap on a penalised
+    ``GMMResult`` and an unpenalised one (fit on the same data with
+    the same initial point) should produce numerically-identical K,
+    S, J distributions because the bootstrap formula doesn't
+    reference the optimiser at all.
+    """
+
+    rng = np.random.default_rng(20260523)
+    data = jnp.asarray(rng.standard_normal(size=50).astype(np.float64))
+
+    def gi_jax(theta, observation):
+        return observation - theta[0]
+
+    manifold = Manifold.from_pymanopt(PymanoptEuclidean(1))
+    restriction = MomentRestriction(
+        gi_jax=gi_jax,
+        data=data,
+        manifold=manifold,
+        backend="jax",
+        parameter_labels=["theta"],
+    )
+
+    gmm_un = GMM(
+        restriction,
+        weighting=FixedWeighting(np.eye(1)),
+        initial_point=jnp.array([0.0]),
+    )
+    gmm_pen = GMM(
+        restriction,
+        weighting=FixedWeighting(np.eye(1)),
+        initial_point=jnp.array([0.0]),
+        penalty=lambda theta: 0.5 * theta[0] ** 2,
+    )
+
+    res_un = gmm_un.estimate(
+        optimizer_kwargs={"min_gradient_norm": 1e-12, "max_iterations": 500}
+    )
+    res_pen = gmm_pen.estimate(
+        optimizer_kwargs={"min_gradient_norm": 1e-12, "max_iterations": 500}
+    )
+
+    boot_un = res_un.k_statistic_bootstrap(
+        theta_0=jnp.array([0.5]), n_replicates=100, rng=7
+    )
+    boot_pen = res_pen.k_statistic_bootstrap(
+        theta_0=jnp.array([0.5]), n_replicates=100, rng=7
+    )
+
+    # Observed K, S, J at the same theta_0: bit-identical.
+    assert np.isclose(boot_un.K_observed, boot_pen.K_observed, atol=1e-10)
+    assert np.isclose(boot_un.J_observed, boot_pen.J_observed, atol=1e-10)
+    assert np.isclose(boot_un.S_observed, boot_pen.S_observed, atol=1e-10)
+    # Bootstrap distributions: same seed → same signs → same K* per replicate.
+    assert np.allclose(boot_un.K_bootstrap, boot_pen.K_bootstrap, atol=1e-10)
+    assert np.allclose(boot_un.J_bootstrap, boot_pen.J_bootstrap, atol=1e-10)
+    # p-values match too.
+    assert boot_un.p_K_bootstrap == boot_pen.p_K_bootstrap
+    assert boot_un.p_K_asymptotic == boot_pen.p_K_asymptotic
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion 5: cluster-aware degenerate case
+# ---------------------------------------------------------------------------
+def test_cluster_aware_with_cluster_size_one_matches_iid() -> None:
+    """``cluster_index = np.arange(N)`` (singleton clusters) == iid bootstrap.
+
+    With each observation in its own cluster, the cluster-wild
+    bootstrap draws an independent sign per observation -- exactly
+    the same scheme as the iid bootstrap.  Same RNG seed should give
+    bit-identical bootstrap distributions.
+    """
+
+    result = _well_conditioned_fit()
+    N = 100
+
+    boot_iid = result.k_statistic_bootstrap(
+        theta_0=jnp.array([0.5]), n_replicates=100, rng=11
+    )
+    boot_singleton = result.k_statistic_bootstrap(
+        theta_0=jnp.array([0.5]),
+        n_replicates=100,
+        cluster_index=np.arange(N),
+        rng=11,
+    )
+
+    # Same RNG seed + same effective scheme ⇒ identical signs ⇒
+    # identical bootstrap distributions.  Note that the *method*
+    # label differs ("iid" vs "cluster_wild"), but the numerics match.
+    assert boot_iid.method == "iid"
+    assert boot_singleton.method == "cluster_wild"
+    assert boot_singleton.cluster_info is not None
+    assert boot_singleton.cluster_info["num_clusters"] == N
+    assert np.allclose(boot_iid.K_bootstrap, boot_singleton.K_bootstrap, atol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion 6: pickle round-trip
+# ---------------------------------------------------------------------------
+def test_kstat_bootstrap_result_pickles_roundtrip(tmp_path) -> None:
+    """``KStatBootstrapResult`` survives a pickle round-trip."""
+
+    result = _well_conditioned_fit()
+    boot = result.k_statistic_bootstrap(
+        theta_0=jnp.array([0.5]), n_replicates=50, rng=42
+    )
+
+    pickle_path = tmp_path / "kstat_boot.pkl"
+    with pickle_path.open("wb") as f:
+        pickle.dump(boot, f)
+    with pickle_path.open("rb") as f:
+        restored = pickle.load(f)
+
+    assert isinstance(restored, KStatBootstrapResult)
+    assert restored.K_observed == boot.K_observed
+    assert restored.J_observed == boot.J_observed
+    assert np.allclose(restored.K_bootstrap, boot.K_bootstrap)
+    assert np.allclose(restored.J_bootstrap, boot.J_bootstrap)
+    assert restored.df_K == boot.df_K
+    assert restored.df_S == boot.df_S
+    assert restored.p_K_bootstrap == boot.p_K_bootstrap
+    assert restored.p_K_asymptotic == boot.p_K_asymptotic
+    assert restored.n_replicates == boot.n_replicates
+    assert restored.method == boot.method
+
+
+# ---------------------------------------------------------------------------
+# Additional coverage: input validation
+# ---------------------------------------------------------------------------
+def test_bootstrap_requires_explicit_theta_0() -> None:
+    """``theta_0`` is required; calling without it raises ``TypeError``."""
+
+    result = _well_conditioned_fit()
+    with pytest.raises(TypeError):
+        result.k_statistic_bootstrap(n_replicates=10)
+
+
+def test_bootstrap_cluster_index_length_must_match_N() -> None:
+    """Wrong-length ``cluster_index`` raises ``ValueError`` with a clear message."""
+
+    result = _well_conditioned_fit()
+    bad_clusters = np.arange(7)  # N is 100
+    with pytest.raises(ValueError, match="cluster_index has 7"):
+        result.k_statistic_bootstrap(
+            theta_0=jnp.array([0.5]),
+            n_replicates=10,
+            cluster_index=bad_clusters,
+        )
+
+
+def test_cluster_aware_two_cluster_design_has_correct_info() -> None:
+    """Two-cluster fixture surfaces ``cluster_info`` correctly."""
+
+    result = _well_conditioned_fit()
+    N = 100
+    # First half in cluster 0, second half in cluster 1.
+    clusters = np.concatenate([np.zeros(N // 2), np.ones(N - N // 2)])
+
+    boot = result.k_statistic_bootstrap(
+        theta_0=jnp.array([0.5]),
+        n_replicates=20,
+        cluster_index=clusters,
+        rng=0,
+    )
+
+    assert boot.method == "cluster_wild"
+    assert boot.cluster_info is not None
+    assert boot.cluster_info["num_clusters"] == 2
+    assert boot.cluster_info["source"] == "argument"


### PR DESCRIPTION
## Summary

Closes #25.  Cluster-wild bootstrap of the Kleibergen K-statistic at an explicit `theta_0`, intended for finite-sample / cluster-aware overidentification testing where the asymptotic `chi^2(p)` is a thin approximation.

**Stacked on PR #26.**  Branched off the guard-relaxation branch because the bootstrap is meant to be callable on penalised fits, and #26 is the prerequisite for `k_statistic(theta_0=...)` to be coherent there.  GitHub will auto-retarget this to `main` once #26 merges.

## What ships

| Surface | Detail |
|---------|--------|
| `rademacher_signs(n, rng)` | Pure +/-1 Rademacher signs, sibling to the existing `rademacher_weights` (which is the `{0, 2}` shifted variant for the fit-replication bootstrap).  Used by the K-stat bootstrap to multiply centred moment contributions; mean-zero signs give a bootstrap with `E[g_bar*] = 0` under H0. |
| `KStatBootstrapResult` | Frozen dataclass: observed `K`, `S`, `J` plus per-replicate arrays; both percentile (bootstrap) and `chi^2` (asymptotic) p-values reported alongside each other; `cluster_info` surfaces the source (argument override vs. restriction default) so pickled results are self-describing. |
| `k_statistic_bootstrap_for_result` in `econometrics/bootstrap.py` | The implementation.  Computes the data-side ingredients once, caches the projection `P = Omega^{-1} D (D' Omega^{-1} D)^{-1} D' Omega^{-1}` so each replicate's `K*` is a single quadratic form, and vectorises the bootstrap loop via `numpy.einsum` over `(n_replicates, N)` sign matrices.  `Omega` is held fixed at the sample value (standard wild-bootstrap recipe for test statistics). |
| `GMMResult.k_statistic_bootstrap` | Thin wrapper around the bootstrap.py implementation, mirroring how `k_statistic` is exposed.  Required kwarg `theta_0` (no default). |
| Cluster resolution | Priority order: `cluster_index` argument > `restriction.clusters` > iid (one sign per observation). |
| Scalar-moment handling | `moment_contributions` returns a 1-D array of length `N` when `ell == 1`; the implementation promotes to `(N, 1)` internally so the matmul is uniform across scalar and vector moments. |

## Tests (10 new in `tests/econometrics/test_k_statistic_bootstrap.py`)

Covering #25's six acceptance criteria plus three for robustness:

- [x] `rademacher_signs` returns +/-1 with empirical mean ~ 0.
- [x] Bootstrap returns correct shape and finite stats.
- [x] **AC2**: Bootstrap `p_K` and asymptotic `p_K` agree to within MC error on a well-conditioned standard-normal mean-estimation fixture.
- [x] **AC3**: Bootstrap still returns finite, well-defined stats on a rank-1 under-identified design where `ridge_inverse` fires its cap.
- [x] **AC4**: Penalty independence -- same seed, same `theta_0`, identical bootstrap distributions between penalised and unpenalised `GMMResult` s fit on the same data.
- [x] **AC5**: Cluster-aware with singleton clusters reproduces iid bootstrap bit-for-bit at the same seed.
- [x] **AC6**: Pickle round-trip on `KStatBootstrapResult`.
- [x] `theta_0` required; calling without raises `TypeError`.
- [x] `cluster_index` length must match `N`; clear `ValueError` message.
- [x] Two-cluster fixture surfaces `cluster_info` correctly.

## Verification gates

- `make quick-check`: ruff + black + mypy clean, **182 passed, 1 skipped** (+10 new tests vs. the 172 inherited from #26's branch).
- `gitnexus_detect_changes`: **LOW** risk; no execution flows affected (the new function is additive).

## Cross-references

- **#25** (closes on merge).
- **#21** still open; specifically tracks `K(theta_hat_pen)` under penalty, which the bootstrap explicitly does *not* address since the implementation takes `theta_0` as required.
- **#18**: the cap on `ridge_inverse` (PR #23, merged) is what makes acceptance criterion 3 well-defined; the bootstrap inherits the cap per inversion.

## Test plan

- [x] `make quick-check` green locally.
- [ ] CI green on this branch (expect the usual ~30-45 min window).
- [ ] After merge: K-Aggregators side runs `result.k_statistic_bootstrap(theta_0=...)` on a real cluster-omega pickle and compares bootstrap vs. asymptotic p-values as the empirical validation of `cond(D'WD) ~ 4e9` vs. `1e16` cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)