### PR TITLE
Docstring caveat: optimizer_health targets cap-hit plateaus, not runaway

### DIFF
--- a/src/manifoldgmm/econometrics/gmm.py
+++ b/src/manifoldgmm/econometrics/gmm.py
@@ -58,6 +58,28 @@ def _maybe_warn_optimizer_health(result: GMMResult) -> None:
     gradient norms, missing stopping criterion) skips the check
     entirely -- the warning fires only when all three signals are
     available and aligned.
+
+    Scope and limitations
+    ---------------------
+    The predicate above targets **MAX_INNER_ITER plateaus** -- runs
+    where the inner truncated-CG repeatedly hits its iteration cap
+    without progress and the outer loop terminates on a resource
+    budget.  It is **not** designed to flag *post-convergence runaway*
+    pathologies where the optimizer terminates *successfully* on a
+    tolerance (``stopping_criterion = "min grad norm"``) but lands at
+    an iterate the user wouldn't want to use -- e.g., the K-Aggregators
+    exp-link runaway documented in #19's empirical comment, where
+    ``c_0 = 41.5`` and ``theta(0) = 9.3e18`` with zero cap-hits and a
+    steeply negative ``tail_grad_slope``.  That pathology is a
+    property of the *result*, not the trajectory, and this warning
+    correctly does not fire on it.
+
+    For post-convergence runaway / weak-identification detection,
+    inspect :meth:`GMMResult.compute_hessian_cond` (with
+    ``exclude_gauge=True`` on K>=2 quotient manifolds per #32) -- a
+    large condition number paired with a healthy trajectory is the
+    runaway signature.  See #10 / #32 for the empirical mapping
+    between diagnostic and pathology.
     """
 
     health = result.optimizer_health
@@ -831,6 +853,31 @@ class GMMResult:
         See :meth:`compute_hessian_cond` for a complementary curvature
         diagnostic; together these distinguish "stalled because the
         budget ran out" from "stalled because the geometry is bad".
+
+        Scope: signatures captured and missed
+        -------------------------------------
+        These fields **capture** the MAX_INNER_ITER plateau signature
+        (``inner_cap_hit_frac`` near 1, ``tail_grad_slope`` near 0,
+        ``optimizer_report["converged"] is not True``) that issue #10
+        was opened against.  The :class:`~manifoldgmm._warnings.ConvergenceWarning`
+        emitted by :func:`_maybe_warn_optimizer_health` fires when all
+        three signals align.
+
+        These fields do **not** capture *post-convergence runaway*: a
+        run that converges cleanly on a tolerance but lands at an
+        iterate the user wouldn't want (e.g., the K-Aggregators
+        exp-link runaway with ``c_0 = 41.5`` and ``theta(0) = 9.3e18``
+        documented in #19's empirical comment).  On those runs every
+        field here looks healthy (``inner_cap_hit_frac == 0``,
+        ``tail_grad_slope`` strongly negative,
+        ``optimizer_report["converged"] is True``) -- the pathology is
+        a property of the *result*, not the trajectory.
+
+        For runaway / weak-identification detection, use
+        :meth:`compute_hessian_cond` with ``exclude_gauge=True`` on
+        K>=2 quotient manifolds per #32.  A large condition number
+        paired with a healthy ``optimizer_health`` reading is the
+        runaway signature.
         """
 
         report = self.optimizer_report


### PR DESCRIPTION
## Summary

Documentation-only follow-up flagged in PR #33's empirical analysis and the post-session ledger.

#10's `optimizer_health` diagnostics and the `ConvergenceWarning` emitted by `_maybe_warn_optimizer_health` were designed for the **MAX_INNER_ITER plateau pathology** (inner-CG repeatedly caps + outer terminates on a resource budget + flat gradient tail).  The K-Aggregators exp-link runaway documented in #19's empirical comment has the opposite signature:

| Signal | K-Aggregators exp-link K=1 runaway | What the warning targets |
|--------|------------------------------------|--------------------------|
| `inner_cap_hit_frac` | **0** | > 0.5 |
| `tail_grad_slope` | **-0.65** (steeply negative) | ≈ 0 |
| `optimizer_report["converged"]` | **True** (min grad norm) | not True |
| `c_0` at termination | **41.5** (runaway) | n/a |

The warning correctly does **not** fire on the runaway -- that pathology is a property of the *result*, not the trajectory.  But a future reader of `optimizer_health`'s docstring could reasonably conclude "no warning = fit is healthy" and miss the diagnostic mismatch.

## What ships (docstring only)

Two `Scope` paragraphs:

- **`_maybe_warn_optimizer_health` docstring**: new "Scope and limitations" section documenting what the predicate targets and what it doesn't, with explicit pointer to `compute_hessian_cond(exclude_gauge=True)` (per #32) as the runaway diagnostic.
- **`GMMResult.optimizer_health` property docstring**: parallel "Scope: signatures captured and missed" section under the existing Notes, same `compute_hessian_cond` cross-reference.

No code changes, no test changes.

## Verification

- `make quick-check`: ruff + black + mypy clean, **203 passed, 1 skipped** (unchanged from main; docstring-only).
- No `gitnexus_detect_changes` impact analysis needed.

## Cross-references

- #10 (parent: `optimizer_health` + the `ConvergenceWarning` this PR documents the scope of).
- #19's empirical comment (the K-Aggregators runaway data establishing what the warning misses).
- #32 (the gauge-aware diagnostic that is the *correct* runaway detector — the new docstring points readers there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)