### PR TITLE
Own JAX x64 configuration and lock it with a regression test

### DIFF
--- a/src/manifoldgmm/__init__.py
+++ b/src/manifoldgmm/__init__.py
@@ -7,6 +7,8 @@ econometrics-layer abstractions for moment restrictions.
 
 from importlib.metadata import PackageNotFoundError, version
 
+from . import _jax_config as _jax_config  # noqa: F401  (configures JAX x64)
+
 try:
     __version__ = version("manifoldgmm")
 except PackageNotFoundError:

--- a/src/manifoldgmm/_jax_config.py
+++ b/src/manifoldgmm/_jax_config.py
@@ -1,0 +1,13 @@
+"""Process-wide JAX configuration applied at package import time.
+
+Importing this module enables 64-bit precision in JAX.  The GMM objective
+``g' W g`` and its Hessian are conditioning-sensitive; running JAX in its
+default float32 mode silently degrades the inner truncated-CG and the
+Wald-test covariances.  pymanopt's JAX backend currently enables x64 on
+import as well, but we set it here so the requirement is owned by this
+package and survives upstream changes.
+"""
+
+import jax
+
+jax.config.update("jax_enable_x64", True)

--- a/tests/test_float64_enforcement.py
+++ b/tests/test_float64_enforcement.py
@@ -1,0 +1,22 @@
+"""Regression test: importing ``manifoldgmm`` enables JAX float64.
+
+The GMM objective ``g' W g`` and its Hessian are conditioning-sensitive;
+running JAX in its default float32 mode silently degrades the inner
+truncated-CG and the Wald-test covariances.  Keep this guarantee local
+to our package so future upstream changes in pymanopt cannot quietly
+turn it off.
+"""
+
+import subprocess
+import sys
+
+
+def test_import_manifoldgmm_enables_x64() -> None:
+    code = (
+        "import manifoldgmm; "
+        "import jax; "
+        "import jax.numpy as jnp; "
+        "assert jax.config.read('jax_enable_x64'), 'x64 disabled'; "
+        "assert jnp.zeros(1).dtype == jnp.float64, jnp.zeros(1).dtype"
+    )
+    subprocess.run([sys.executable, "-c", code], check=True)


### PR DESCRIPTION
## Summary
- Move the `jax_enable_x64 = True` flag out of "we inherit it from pymanopt" into a tiny `_jax_config` module imported by `manifoldgmm/__init__.py`. The requirement is now owned by this package and survives upstream changes in pymanopt's JAX backend.
- Add `tests/test_float64_enforcement.py`, a subprocess test that fails if `import manifoldgmm` no longer yields float64 by default.

## Why
The GMM criterion `g'Wg` and its Hessian-vector products are conditioning-sensitive. Float32 silently costs extra truncated-CG iterations and noisy Wald covariances. Pymanopt's `_jax.py` happens to flip the flag today, but losing that on a future bump would degrade numerical behavior without a single test failing.

## Test plan
- [x] `make quick-check` (204 passed, 1 skipped)
- [x] New `test_import_manifoldgmm_enables_x64` passes


---
_Generated by [Claude Code](https://claude.ai/code/session_01FiBYcMA5BpQpMgN3XXfRgb)_