### PR TITLE
Catalogue and test the optimizer_kwargs surface on GMM.estimate

### DIFF
--- a/src/manifoldgmm/econometrics/gmm.py
+++ b/src/manifoldgmm/econometrics/gmm.py
@@ -1918,8 +1918,57 @@ class GMM:
             Hard cap on the number of reweighting stages when iterating to
             convergence.
         optimizer_kwargs:
-            Keyword arguments forwarded to the optimizer constructor or to
-            an already-instantiated optimizer.
+            Keyword arguments forwarded to the optimizer.  Forwarding is
+            partitioned at the call site (see
+            :meth:`_split_optimizer_kwargs`):
+
+            **Forwarded to** ``LoggingTrustRegions.__init__`` (or the
+            user-supplied optimizer class), via ``**kwargs`` on pymanopt's
+            ``TrustRegions``:
+
+            - ``min_gradient_norm`` (default ``1e-6``): Riemannian gradient
+              norm at which the outer loop terminates.  For noisy moment
+              objectives a slightly looser ``1e-5`` often saves CG work
+              with no statistical cost.
+            - ``min_step_size`` (default ``1e-10``): minimum step length
+              before declaring stagnation.
+            - ``max_iterations`` (default ``1000``): outer trust-region
+              iteration cap.
+            - ``max_time`` (default ``float('inf')``): wall-clock cap.
+            - ``kappa`` / ``theta`` (CG tolerances), ``rho_prime``
+              (acceptance threshold), ``use_rand``, ``rho_regularization``:
+              pymanopt ``TrustRegions`` knobs; default values rarely need
+              tuning.
+            - ``verbosity``, ``log_verbosity``: pymanopt base-optimizer
+              logging.  Set by ``verbose=`` below when omitted.
+            - ``adaptive_maxinner`` (default ``False``),
+              ``adaptive_threshold`` / ``adaptive_window`` /
+              ``adaptive_ceiling``: opt in to the
+              :class:`LoggingTrustRegions` policy that doubles ``maxinner``
+              when the inner CG repeatedly hits the cap.  Helpful for
+              high-dim manifolds where the default ``maxinner =
+              manifold.dim`` is too small.
+
+            **Forwarded to** ``optimizer.run(...)``:
+
+            - ``mininner`` (default ``1``): minimum CG iterations per
+              outer step.
+            - ``maxinner`` (default ``manifold.dim``): cap on CG
+              iterations.
+            - ``Delta_bar`` (default ``manifold.typical_dist``): trust-
+              region radius upper bound.
+            - ``Delta0`` (default ``Delta_bar / 8``): initial trust radius.
+
+            Example::
+
+                gmm.estimate(
+                    optimizer_kwargs={
+                        "min_gradient_norm": 1e-5,
+                        "adaptive_maxinner": True,
+                        "maxinner": 50,
+                    },
+                )
+
         verbose:
             Convenience flag for setting optimizer ``verbosity``.
 

--- a/tests/test_optimizer_kwargs_forwarding.py
+++ b/tests/test_optimizer_kwargs_forwarding.py
@@ -1,0 +1,98 @@
+"""Regression tests: ``GMM.estimate(optimizer_kwargs=...)`` actually
+forwards both ``__init__``- and ``run()``-flavoured keys.
+
+The partition logic lives in ``GMM._split_optimizer_kwargs`` and
+``GMM._resolve_optimizer``.  A regression that silently swallowed any
+of these keys would degrade tunability without any other signal --
+fits would just stop responding to the knobs documented on
+``GMM.estimate``.
+
+Two paths are covered:
+
+1. ``__init__``-flavoured kwarg (``min_gradient_norm``) lands on the
+   constructed ``LoggingTrustRegions`` and shows up in the resulting
+   optimizer's attribute.
+2. ``run()``-flavoured kwarg (``maxinner``) is honoured at run time
+   -- we wrap the default optimizer in a sentinel that captures the
+   ``maxinner`` keyword on ``.run`` and assert the captured value.
+3. The opt-in ``adaptive_maxinner`` flag populates the
+   ``maxinner_history`` log key (a side-effect that only fires when
+   the adaptive policy is active in
+   :class:`LoggingTrustRegions._truncated_conjugate_gradient`).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import jax.numpy as jnp
+from manifoldgmm import GMM, Manifold, MomentRestriction
+from manifoldgmm.optimizers import LoggingTrustRegions
+from pymanopt.manifolds import Euclidean as PymanoptEuclidean
+
+
+def _build_gmm() -> GMM:
+    data = jnp.array([1.0, 2.0, 3.0])
+
+    def gi_jax(theta: Any, observation: Any) -> Any:
+        return observation - theta[0]
+
+    restriction = MomentRestriction(
+        gi_jax=gi_jax,
+        data=data,
+        manifold=Manifold.from_pymanopt(PymanoptEuclidean(1)),
+        backend="jax",
+        parameter_labels=["theta"],
+    )
+    return GMM(restriction, initial_point=jnp.array([0.0]))
+
+
+def test_init_kwarg_lands_on_optimizer() -> None:
+    """``min_gradient_norm`` is a ``TrustRegions.__init__`` kwarg.  It
+    must be set on the constructed optimizer."""
+
+    gmm = _build_gmm()
+    custom = 3.14e-5
+    optimizer_seen: list[LoggingTrustRegions] = []
+
+    class _Capturing(LoggingTrustRegions):
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            super().__init__(*args, **kwargs)
+            optimizer_seen.append(self)
+
+    gmm._optimizer = _Capturing
+    gmm.estimate(optimizer_kwargs={"min_gradient_norm": custom})
+
+    assert len(optimizer_seen) >= 1
+    assert optimizer_seen[0]._min_gradient_norm == custom
+
+
+def test_run_kwarg_reaches_optimizer_run() -> None:
+    """``maxinner`` is a ``TrustRegions.run`` kwarg.  It must be
+    captured by ``run()`` rather than silently dropped on the floor."""
+
+    gmm = _build_gmm()
+    captured: dict[str, Any] = {}
+
+    class _CapturingRun(LoggingTrustRegions):
+        def run(self, problem: Any, **kwargs: Any) -> Any:
+            captured.update(kwargs)
+            return super().run(problem, **kwargs)
+
+    gmm._optimizer = _CapturingRun
+    gmm.estimate(optimizer_kwargs={"maxinner": 7})
+
+    assert captured.get("maxinner") == 7
+
+
+def test_adaptive_maxinner_populates_history_log() -> None:
+    """The opt-in adaptive policy only writes ``maxinner_history`` /
+    ``numit_history`` when active."""
+
+    gmm = _build_gmm()
+    res = gmm.estimate(optimizer_kwargs={"adaptive_maxinner": True})
+
+    log = res.optimizer_report.get("log") or {}
+    assert "maxinner_history" in log
+    assert "numit_history" in log
+    assert len(log["maxinner_history"]) == len(log["numit_history"])


### PR DESCRIPTION
## Summary
- Expand the `optimizer_kwargs` entry on `GMM.estimate`'s docstring with a concrete catalogue of accepted keys, split into `__init__`-flavoured (TrustRegions / LoggingTrustRegions construction) and `run()`-flavoured (`mininner`, `maxinner`, `Delta_bar`, `Delta0`) plus a usage example.
- Add `tests/test_optimizer_kwargs_forwarding.py` (3 tests) asserting:
  1. an `__init__` kwarg (`min_gradient_norm`) lands on the constructed optimizer's attribute,
  2. a `run()` kwarg (`maxinner`) is captured by `.run` (not dropped on partition),
  3. the opt-in `adaptive_maxinner` policy actually populates `log["maxinner_history"]` / `log["numit_history"]` -- the side-effect that only fires when the adaptive branch is active in `LoggingTrustRegions._truncated_conjugate_gradient`.

## Why
All these knobs were *already* tunable via `optimizer_kwargs` — but the docstring said only "Keyword arguments forwarded to the optimizer." With no catalogue, even adaptive_maxinner (already implemented in `LoggingTrustRegions`) was effectively undiscoverable. The regression tests guard the partition logic in `_split_optimizer_kwargs` so a future refactor can't silently swallow a key.

## Test plan
- [x] `make quick-check FILES=...` (3 passed, ~7s)
- [x] No behaviour change; existing tests unaffected.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FiBYcMA5BpQpMgN3XXfRgb)_