### PR TITLE
NumericalWarning: multi-inherit from dgp_protocol.NumericalWarning

### DIFF
--- a/docs/design/v2_dgp.org
+++ b/docs/design/v2_dgp.org
@@ -1,0 +1,359 @@
+#+TITLE: v2: GMM Consumes a DataGeneratingProcess
+#+AUTHOR: Sue the Coder (with Ethan Ligon)
+#+DATE: 2026-05-25
+#+OPTIONS: toc:t num:nil ^:nil
+
+* Summary
+
+ManifoldGMM v2 reframes the estimator as a *functional of a
+DataGeneratingProcess* (Manski 1988, analog estimation).  The
+estimator becomes agnostic about whether data is iid or
+cluster-correlated or hierarchically sampled; that information lives
+entirely in the =DataGeneratingProcess= object that the user
+constructs and hands to the GMM.
+
+The consumer change is one extra kwarg at construction:
+
+#+begin_src python
+  import dgp_protocol as dp
+  from manifoldgmm.econometrics import GMM
+
+  dgp = dp.EmpiricalDGP(observation=X, sampling=dp.ClusteredSampling(clusters), seed=0)
+
+  gmm = GMM(moment_func=g, dgp=dgp, manifold=M, weighting=cue, initial_point=theta_0)
+  result = gmm.estimate()
+  bootstrap = gmm.bootstrap(B=1000)
+#+end_src
+
+Internally, three things happen:
+
+1. The point estimate solves the analog moment condition at
+   ~dgp.data~ exactly as it does today.
+2. The asymptotic SE uses the *DGP-side* moment-vector covariance
+   ~dgp.sample_distribution.moment_covariance(theta_hat, g_i)~ in
+   place of the estimator-side cluster-robust sandwich filling.  The
+   DGP's sampling design (iid, cluster, two-stage, ...) controls the
+   covariance recipe; the GMM stops caring.
+3. The DGP-driven bootstrap is a one-line loop over =dgp.draw()=
+   realizations.  The estimator-side cluster-wild Rademacher
+   bootstrap survives as a parallel route for users who specifically
+   want moment-error resampling.
+
+* Motivation
+
+** What v1 conflates
+
+The v1 ~GMM(MomentRestriction(g, data))~ glues the moment function
+and the data at construction time; downstream code treats =data= as
+an immutable numpy matrix.  Three problems follow:
+
+- *Sampling-design awareness leaks into the estimator.*  Cluster ids
+  are passed as a parameter to the wild bootstrap; clustered inference
+  has its own code path; iid-vs-clustered crosses every inference
+  helper.
+- *Resampling logic and estimation logic live in the same module.*
+  =econometrics/bootstrap.py= knows how to refit and how to resample,
+  even though "how to resample" depends on the sampling design, not
+  the estimator.
+- *Power studies require ad-hoc plumbing.*  Generating synthetic data
+  at a known ~theta_0~ and refitting requires the user to wire up
+  their own loops; there is no first-class object for "the
+  distribution my data is drawn from."
+
+** What the DGP encapsulates
+
+A =DataGeneratingProcess= is the *stand-in distribution* against
+which an analog estimator is defined.  Two members on the Protocol:
+
+- =dgp.data=: the observed realization, frozen.
+- =dgp.draw(size=None)=: a fresh realization.
+
+Two further surfaces exposed by the package's concrete containers
+(=EmpiricalDGP=, =ParametricDGP=, =TwoStageDGP=):
+
+- *P-side (per-observation marginal):*
+  =dgp.expect=/=mean=/=var=/=cov= for the row-wise marginal.  Used
+  for analog estimators (~theta_hat~ is the analog of a population
+  functional taken w.r.t. this marginal).
+- *D-side (dataset-level sampling distribution):*
+  =dgp.sample_distribution.expect=/=cov=/=moment_covariance= for
+  the sampling distribution of statistics of the whole realization.
+  Used for inference (the sampling distribution of ~theta_hat~).
+
+The split between P-side and D-side is the workhorse for v2: the
+moment function operates on P-side (it is a per-row functional); the
+inference machinery operates on D-side (sandwich SE, bootstrap of
+~theta_hat~).  Both come from the same DGP; the DGP knows how to
+implement each surface analytically or by Monte Carlo.
+
+* Consumer surface
+
+** GMM constructor
+
+#+begin_src python
+  class GMM:
+      def __init__(
+          self,
+          moment_func: Callable[[ManifoldPoint, Any], Any],
+          dgp: DataGeneratingProcess,
+          *,
+          manifold: ManifoldData,
+          weighting: WeightingStrategy | None = None,
+          optimizer: type[Optimizer] | Optimizer | None = None,
+          initial_point: ManifoldPoint | None = None,
+          penalty: PenaltyStrategy | None = None,
+      ) -> None: ...
+#+end_src
+
+The =moment_func= now takes ~(theta, data)~ explicitly:
+
+#+begin_src python
+  def g(theta: ManifoldPoint, data: np.ndarray) -> np.ndarray:
+      """Per-row moment contributions; shape (N, k)."""
+      ...
+#+end_src
+
+The GMM derives a =MomentRestriction= internally as
+~MomentRestriction(g, dgp.data)~ at construction; the restriction
+is still the home for backend-aware vectorization, gN, omega_hat
+(deprecated; see below).  =MomentRestriction(g, data)= remains a
+public constructor for users who don't want to wrap their data in a
+DGP -- internally the GMM treats this as
+~EmpiricalDGP(observation=data, sampling=IIDSampling())~.
+
+** Estimation
+
+=gmm.estimate(...)= is unchanged in semantics.  It computes
+~theta_hat = argmin_theta g_bar(theta)' W g_bar(theta) +
+penalty(theta)~ at ~dgp.data~.  Same one-step / two-step / iterated
+options; same =GMMResult=.
+
+** Inference (D-side via SampleDistribution)
+
+The =GMMResult.tangent_covariance= and =manifold_covariance= helpers
+ask the DGP for the moment-vector covariance:
+
+#+begin_src python
+  Omega_hat = result.dgp.sample_distribution.moment_covariance(
+      theta_hat, result.moment_restriction.g_i
+  )
+  # ... sandwich formula in tangent space ...
+#+end_src
+
+The estimator no longer carries a cluster-robust outer-product path.
+Whether ~Omega_hat~ comes from a 1/N i.i.d. outer product or a cluster
+score-sum outer product is decided inside =SampleDistribution=.
+
+** Bootstrap
+
+Two routes; both methods on =GMM=:
+
+*** Raw-data bootstrap (DGP-driven)
+
+#+begin_src python
+  bs = gmm.bootstrap(B=1000, seed=0)
+  bs.theta_distribution        # shape (B,) of ManifoldPoint
+  bs.cov_in_tangent(theta_hat) # bootstrap covariance in tangent space
+  bs.confidence_interval(...)
+#+end_src
+
+Implementation:
+
+#+begin_src python
+  def bootstrap(self, B: int, *, seed: int | None = None) -> BootstrapResult:
+      """Refit on B fresh draws from ``self.dgp``."""
+      rng = np.random.default_rng(seed) if seed is not None else self.dgp._rng
+      children = [self.dgp.with_rng(s) for s in rng.spawn(B)]
+      thetas = []
+      for child in children:
+          # Each child draws once, then becomes a DGP whose .data is
+          # that draw.  Refitting reads .data, so this is the right
+          # rebinding pattern.
+          rebound = child.with_data(child.draw())
+          sibling = self.with_dgp(rebound)
+          thetas.append(sibling.estimate().theta)
+      return BootstrapResult(thetas, base=self)
+#+end_src
+
+The sampling design lives in =dgp= (=ClusteredSampling=,
+=IIDSampling=, etc.); ~gmm.bootstrap~ is design-agnostic.
+
+*** Moment-error bootstrap (estimator-side)
+
+The v1 cluster-wild Rademacher bootstrap stays as
+~gmm.moment_error_bootstrap(B, ...)~.  It does *not* call
+=dgp.draw()=; it resamples the residual moment vectors at
+~theta_hat~.  Available for weak-identification finite-sample
+inference where the raw-data bootstrap is too noisy (the K-statistic
+bootstrap, in particular, uses this route).
+
+The cluster ids needed by Rademacher resampling come from the DGP's
+sampling design when it is a =ClusteredSampling=:
+
+#+begin_src python
+  from dgp_protocol import ClusteredSampling
+  if isinstance(gmm.dgp.sampling, ClusteredSampling):
+      cluster_ids = gmm.dgp.sampling.cluster_ids
+  else:
+      cluster_ids = None     # iid case: still well-defined
+#+end_src
+
+That introspection is the *only* place the estimator looks inside the
+DGP's sampling design.  Everything else is mediated through the
+Protocol surface.
+
+* Migration map
+
+| v1 entry point                              | v2 equivalent                                                  |
+|---------------------------------------------+----------------------------------------------------------------|
+| =MomentRestriction(g, data)=                | unchanged; still public                                        |
+| =MomentRestriction.omega_hat(theta)=        | deprecated; use =dgp.sample_distribution.moment_covariance=   |
+| =GMM(restriction, ...)=                     | unchanged; still public                                        |
+| =GMM(restriction, ...).estimate()=          | unchanged                                                      |
+| =GMMResult.tangent_covariance()=            | unchanged externally; rewires internally to DGP-side Omega    |
+| =GMMResult.k_statistic(...)=                | unchanged                                                      |
+| =GMMResult.k_statistic_bootstrap(...)=      | unchanged; uses =gmm.moment_error_bootstrap= under the hood   |
+| =econometrics/bootstrap.cluster_wild(...)=  | wrapped as =gmm.moment_error_bootstrap(...)=                  |
+| =econometrics/simulation.power_study(...)=  | trivially replaced by =gmm.bootstrap= on a synthetic =dgp=    |
+
+* What stays unchanged
+
+- Manifold machinery (=ManifoldPoint=, =TangentSpace=, =retract=,
+  =proj=, etc.).  No DGP awareness needed.
+- Optimizer machinery (line-search, conjugate gradient, ...).
+- =WeightingStrategy= and =PenaltyStrategy= protocols.  =CUEWeighting=
+  still reads moment values via =MomentRestriction= -- no change.
+- =Diagnostics= class.
+- Result types (=GMMResult=, =KStatisticResult=, =WaldTestResult=).
+- All ASCII-LaTeX-only conventions; all naming/notation conventions
+  in =docs/standards/naming_notation.org=.
+
+* What gets removed or deprecated
+
+- =MomentRestriction.omega_hat= -- estimator-side cluster-robust
+  outer-product code path.  Replaced by
+  =dgp.sample_distribution.moment_covariance=.  Marked
+  =@deprecated= for one minor release, then removed.
+- Several sampling-design-aware utilities in
+  =econometrics/bootstrap.py= and =econometrics/simulation.py= that
+  duplicate logic now living in =dgp_protocol=.
+
+* Tests
+
+** Strategy
+
+V2 ships its own test directory (=tests/v2/=) that exercises the
+DGP-based API end-to-end.  The v1 test suite stays in =tests/= as
+the back-compat oracle: any v1 test that constructs ~GMM(restriction,
+...)~ must continue to pass bit-for-bit under v2 until the
+deprecation window closes.  The v2 suite checks:
+
+- Point estimate agreement between
+  ~GMM(restriction, ...).estimate()~ and
+  ~GMM(moment_func, dgp=EmpiricalDGP(data), ...).estimate()~.
+- Sandwich SE agreement between v1 and v2 paths under iid sampling.
+- Sandwich SE under clustered sampling: v1 cluster-robust formula
+  vs v2 =sample_distribution.moment_covariance= on the same data
+  with =ClusteredSampling=.
+- DGP-driven bootstrap on a small known-truth Gaussian power study
+  (=ParametricDGP(distribution=multivariate_normal(theta_0, ...))=).
+  Recovers ~theta_0~ within MC error; bootstrap variance close to
+  asymptotic.
+- Moment-error bootstrap delegates to existing
+  =econometrics/bootstrap.py= and produces same results as v1.
+
+** Worked example (skeleton)
+
+#+begin_src python
+  # tests/v2/test_dgp_e2e.py
+  import numpy as np
+  import dgp_protocol as dp
+  from manifoldgmm.econometrics import GMM, MomentRestriction
+  from manifoldgmm.manifolds import Euclidean
+
+  def test_gmm_with_empirical_dgp_recovers_v1_point_estimate():
+      rng = np.random.default_rng(0)
+      X = rng.standard_normal(size=(200, 3))
+
+      def g(theta, data):
+          return data - theta  # E[X] = theta moment condition
+
+      M = Euclidean(dim=3)
+      theta_0 = M.point(np.zeros(3))
+
+      # v1 route:
+      gmm_v1 = GMM(restriction=MomentRestriction(g, X), manifold=M,
+                   initial_point=theta_0)
+      result_v1 = gmm_v1.estimate()
+
+      # v2 route:
+      dgp = dp.EmpiricalDGP(observation=X, seed=0)
+      gmm_v2 = GMM(moment_func=g, dgp=dgp, manifold=M,
+                   initial_point=theta_0)
+      result_v2 = gmm_v2.estimate()
+
+      np.testing.assert_allclose(
+          result_v1.theta.array, result_v2.theta.array, atol=1e-12
+      )
+#+end_src
+
+* Phased roll-out
+
+This branch (=v2-dgp=) keeps the design doc and the skeleton
+implementation moving together; merge to ~main~ is gated on:
+
+1. =GMM(moment_func, dgp, ...)= constructs and matches v1 point
+   estimate on iid data.
+2. =gmm.bootstrap(B)= returns sensible Monte Carlo confidence
+   intervals on the Gaussian power study.
+3. =result.tangent_covariance()= internally uses
+   =dgp.sample_distribution.moment_covariance= and agrees with v1
+   under iid sampling.
+4. =gmm.moment_error_bootstrap(B)= is bit-identical to v1's
+   cluster-wild bootstrap.
+
+After merge, follow-up issues:
+
+- Deprecation warnings on =MomentRestriction.omega_hat=.
+- K-statistic bootstrap rewired to =moment_error_bootstrap=.
+- Power-study examples in =examples/= using =ParametricDGP=.
+- README + AGENTS.org updated to feature the DGP-based API.
+
+* Open questions
+
+** =gmm.with_dgp(dgp)= helper
+
+The DGP-driven bootstrap iterates over child DGPs; the natural
+operation is "give me a sibling GMM bound to a different DGP."
+Either as a public method or a private helper.  Lean *private* for
+v2.0; promote to public if user code needs it.
+
+** =MomentRestriction.g_i= vs =moment_func= duplication
+
+The v1 =MomentRestriction= already wraps the moment function with
+backend-aware vectorization.  =SampleDistribution.moment_covariance=
+needs the *raw* per-row moment function ~g_i(theta, X_i)~; the v2
+GMM should expose the underlying ~g_i~ for DGP-side use.  Concretely:
+
+#+begin_src python
+  Omega_hat = dgp.sample_distribution.moment_covariance(
+      theta_hat, gmm.moment_restriction.g_i
+  )
+#+end_src
+
+requires =MomentRestriction.g_i= as a public attribute.  Cheap
+addition; do it as part of the skeleton.
+
+** Backward compatibility window
+
+Suggest two minor releases:
+
+- ~0.4.0~ (v2 ships): both ~MomentRestriction-only~ and ~dgp-based~
+  constructors; =omega_hat= still works; =bootstrap.py= still works
+  alongside DGP-driven bootstrap.
+- ~0.5.0~: =omega_hat= deprecation warning fires; default sandwich
+  path is DGP-side.
+- ~0.6.0~ or ~1.0.0~: =omega_hat= removed; v1-only test paths
+  removed.
+
+Confirm window length when v2 stabilizes.

--- a/docs/release/notes_0.4.0a1.org
+++ b/docs/release/notes_0.4.0a1.org
@@ -1,0 +1,115 @@
+#+TITLE: Release Notes -- v0.4.0a1
+#+AUTHOR: ManifoldGMM Maintainers
+#+DATE: <2026-05-26 Tue>
+#+OPTIONS: toc:nil num:nil
+
+* Summary
+This alpha introduces the v2 GMM consumer surface: estimators take a
+=DataGeneratingProcess= (DGP) at construction and gain a DGP-driven raw-data
+bootstrap.  The DGP layer encapsulates sampling design (iid, cluster, two-stage,
+parametric, ...) so the estimator becomes sampling-design-agnostic and the same
+=GMM(moment_func, dgp, ...)= machinery serves point estimation, power studies,
+and cluster-by-unit panel inference.  The v2 path adds an autodetected
+closed-form fast path for linear-in-parameters moments (with per-stage dispatch
+so two-step / iterated linear GMM gets the 3SLS-equivalent fast path).
+
+Pre-v2 callers using =GMM(restriction, ...)= continue to work bit-identically;
+no source changes required.
+
+* Highlights
+- New =GMM= constructor path: =GMM(moment_func=g, dgp=my_dgp, manifold=M, ...)=
+  consuming any object that satisfies the
+  [[https://github.com/ligon/DGP_Protocol][=dgp_protocol.DataGeneratingProcess=]] Protocol (data + draw).
+- New =GMM.bootstrap(B, seed=None)= method: refits the estimator on =B= fresh
+  =dgp.draw()= realizations.  Cluster-by-unit, parametric power study, and raw
+  iid bootstrap fall out by choice of DGP without estimator-side changes.
+- New =BootstrapResult= dataclass holding the bootstrap distribution of theta.
+- Linearity autodetection (=detect_linear=True= by default): a jaxpr-walker
+  determines whether the moment function is affine in =theta=; when so (and
+  the manifold is flat and the weighting is theta-independent), each GMM
+  stage solves in closed form via =theta_hat = -(B' W B)^{-1} B' W a=.  This
+  fires *per stage*, so two-step or iterated linear GMM gets the 2SLS / 3SLS-
+  equivalent closed-form path automatically.
+- New =assume_linear= kwarg lets the user assert linearity without invoking the
+  walker; =verbosity= (default 0) reports linearity status to stdout at level
+  1 and per-stage closed-form diagnostics at level 2.
+- Bootstrap weighting correctness fix: a v2 bootstrap sibling now re-coerces
+  its weighting against its own MomentRestriction (so =CUEWeighting=
+  rebuilds per replication on the resampled data instead of carrying the
+  parent's Omega-hat).
+- Four end-to-end v2 examples shipped under =tests/v2/=:
+  - =bernoulli_v2= -- linear just-identified analog estimator;
+  - =gaussian_mixture_v2= -- nonlinear over-identified (4 moments, 3 params,
+    df=1 Hansen J) via two-step GMM, consuming the upstream
+    =coin_plus_noise= DGP;
+  - =two_way_fe_v2= -- unbalanced-panel two-way fixed-effects via FWL
+    projection, with both the parametric and empirical cluster-by-unit
+    bootstrap paths demonstrated side-by-side from the same GMM;
+  - =test_linearity= -- the autodetection / closed-form path coverage,
+    including the bump-function rejection that motivated the static-walker
+    design.
+- =NumericalWarning= now multi-inherits from =dgp_protocol.NumericalWarning=
+  and =UserWarning=.  A single =filterwarnings(category=dgp_protocol.NumericalWarning)=
+  catches numerical-quality warnings from both layers; existing filters on
+  =UserWarning= or on =manifoldgmm.NumericalWarning= keep working unchanged.
+
+* Design notes
+- =docs/design/v2_dgp.org= records the full v2 consumer-surface design: where
+  the DGP plugs in (constructor), which v1 entry points stay vs migrate, the
+  two-bootstrap strategy (raw-data DGP-driven + estimator-side cluster-wild),
+  and the phased roll-out plan.
+
+* Breaking / notable changes
+- *New runtime dependency on =DGP_Protocol=.*  The =manifoldgmm._warnings=
+  module now imports =dgp_protocol= at module load time (the
+  =NumericalWarning= multi-inheritance), and =GMM= imports the
+  =DataGeneratingProcess= Protocol for its v2 isinstance check.  =import
+  manifoldgmm= therefore requires DGP_Protocol installed.
+
+  - =pip install --upgrade manifoldgmm= -- picks up DGP_Protocol via the
+    declared dep.  No user action needed.
+  - =pip install --no-deps= or hand-managed venvs -- =install
+    dgp_protocol>=0.1.0a0= alongside the upgrade.
+  - Local development with the path dep: =poetry install= picks up the path
+    dep at =../DGP_Protocol=; the lockfile is gitignored as before.
+
+  The dep will move from a path constraint to a PyPI version constraint once
+  DGP_Protocol publishes its first release.
+
+- *=NumericalWarning= MRO change* (cosmetic backward-compat caveat).  The
+  multi-inheritance flips =issubclass(NumericalWarning, RuntimeWarning)= from
+  =False= to =True=.  Code asserting the negative direction (unusual) would
+  need updating; the positive direction (=issubclass(NumericalWarning,
+  UserWarning) == True=) is preserved.
+
+* Backward compatibility for v1 callers
+- =GMM(restriction, ...)= -- unchanged.  The v1 constructor signature is
+  preserved bit-identically; v1 keyword/positional invocations both still work.
+- =MomentRestriction(g, data, ...)= and all subsidiary v1 modules
+  (=WeightingStrategy=, =PenaltyStrategy=, =Optimizer=, =Diagnostics=,
+  =GMMResult=) -- unchanged.
+- v2 fast-path / closed-form dispatch is gated on =self._moment_func is not
+  None=, which is False for v1 callers; the v2 detection runs only on the v2
+  path.  v1 =estimate()= flows through the identical optimizer-driven path it
+  did pre-v2.
+- =gmm.bootstrap(B)= raises a clear =RuntimeError= when called on a
+  v1-constructed GMM (no DGP attached).  Bootstrap was not available in v1, so
+  this is a new feature behind an explicit error message, not a regression.
+
+* Verification
+- =pytest tests/= -- full suite green.
+- =pytest tests/v2/= -- 36 v2 tests pass (skeleton + four examples +
+  linearity).
+- =pytest tests/utils/test_ridge_inverse.py tests/econometrics/test_diagnostics_namespace.py tests/econometrics/test_compute_hessian_cond_gauge.py tests/test_logging_trust_regions.py=
+  -- 55 NumericalWarning-touching tests pass.
+- =ruff check src tests=, =black --check src tests=, =mypy src tests= clean.
+
+* Pending before final tag
+- Wire =GMMResult.tangent_covariance= and the sandwich-SE path through
+  =dgp.sample_distribution.moment_covariance= (currently still uses v1
+  =omega_hat=).
+- Add the estimator-side moment-error =gmm.moment_error_bootstrap(B)= as a
+  second bootstrap route alongside the raw-data =gmm.bootstrap(B)= (K-statistic
+  bootstrap stays here).
+- Replace the local =DGP_Protocol= path dep with a PyPI version constraint once
+  upstream publishes 0.1.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
 ]
 dependencies = [
   "datamat>=0.2.0a1",
+  "DGP_Protocol>=0.1.0a0",
   "pymanopt @ git+https://github.com/pymanopt/pymanopt.git",
   "jax>=0.4.25",
   "joblib (>=1.5.3,<2.0.0)"
@@ -30,6 +31,9 @@ packages = [{ include = "manifoldgmm", from = "src" }]
 python = ">=3.11,<4.0"
 pymanopt = { git = "https://github.com/pymanopt/pymanopt.git" }
 datamat = ">=0.2.0a1"
+# Local path while DGP_Protocol is pre-release; switch to a version
+# constraint once it lands on PyPI.
+DGP_Protocol = { path = "../DGP_Protocol", develop = true }
 jax = ">=0.4.25"
 
 [tool.poetry.extras]

--- a/src/manifoldgmm/_warnings.py
+++ b/src/manifoldgmm/_warnings.py
@@ -4,10 +4,11 @@ The package CLAUDE.md lists a small set of canonical warning categories
 (``NumericalWarning``, ``GaugeWarning``, ``ConvergenceWarning``) that
 downstream code is expected to use rather than bare ``UserWarning``.
 This module is the home for those classes.  Each subclasses
-``UserWarning`` so the standard :mod:`warnings` machinery (filters,
-``warnings.simplefilter``, pytest's ``filterwarnings`` mark, etc.) works
-unchanged, while letting callers target a specific category when they
-want to silence (or escalate) just that family of diagnostics.
+``UserWarning`` (sometimes alongside another base) so the standard
+:mod:`warnings` machinery (filters, ``warnings.simplefilter``,
+pytest's ``filterwarnings`` mark, etc.) works unchanged, while
+letting callers target a specific category when they want to silence
+(or escalate) just that family of diagnostics.
 
 Adding more classes here is cheap; resist the urge to add one per
 warning site.  A category buys filterability for an *audience*: users
@@ -17,6 +18,8 @@ existing :class:`UserWarning`.
 """
 
 from __future__ import annotations
+
+import dgp_protocol
 
 
 class ConvergenceWarning(UserWarning):
@@ -38,7 +41,7 @@ class ConvergenceWarning(UserWarning):
     """
 
 
-class NumericalWarning(UserWarning):
+class NumericalWarning(dgp_protocol.NumericalWarning, UserWarning):
     """A numerical operation completed in a degraded regime.
 
     Emitted from low-level numerical helpers when an iterative procedure
@@ -48,6 +51,18 @@ class NumericalWarning(UserWarning):
     used to spin in a ``while True`` ridge-bump loop on severely
     ill-conditioned matrices (``cond >> target_condition``); the loop
     now caps and emits this warning instead.
+
+    Multiple-inherits from :class:`dgp_protocol.NumericalWarning` so a
+    user filter targeting *either* category catches instances of both
+    -- the upstream package raises its own NumericalWarning from
+    adaptive Monte Carlo budget exhaustion in the distributional-
+    features path, and consumers usually want one filter to cover the
+    whole numerical-quality category regardless of which layer
+    emitted it.  Continues to subclass :class:`UserWarning` so
+    existing filters that broaden over UserWarning still apply
+    (DGP_Protocol's NumericalWarning happens to subclass
+    :class:`RuntimeWarning`, so we cover that lineage too via
+    multiple inheritance).
 
     Filter via the standard :mod:`warnings` interface, e.g.::
 

--- a/src/manifoldgmm/econometrics/_linearity.py
+++ b/src/manifoldgmm/econometrics/_linearity.py
@@ -1,0 +1,379 @@
+"""Linearity autodetection and closed-form GMM for affine moments.
+
+When the moment function ``g(theta, data)`` is affine in ``theta`` and
+the parameter manifold is flat (Euclidean or product of Euclideans),
+the GMM criterion is a quadratic form in ``theta`` and the minimizer
+has the closed form
+
+    theta_hat = -(B' W B)^{-1} B' W a,
+
+where ``a = g_bar(0, data)`` is the constant term and ``B =
+\\partial g_bar / \\partial theta`` is the (constant) Jacobian.  For
+just-identified problems (``k = p``), this simplifies to
+``theta_hat = -B^{-1} a``.  For over-identified problems with a
+data-independent weighting ``W``, the formula gives the GLS / 2SLS-
+style estimator in one matrix solve.
+
+This module provides:
+
+- :func:`is_affine_in_theta`: a jaxpr-level static check that walks
+  the operator graph of ``moment_func`` and verifies that ``theta``
+  flows only through *affine-preserving* primitives.  It's strictly
+  stronger than any numerical check at sample points -- the bump
+  function ``g(x) = 0 for x <= 0, exp(-1/x) for x > 0`` has zero
+  Hessian on ``(-inf, 0)`` but a numerical Hessian check at any
+  ``x < 0`` would falsely conclude "affine"; the jaxpr walker
+  detects the ``exp`` primitive in the conditional branch and
+  rejects.
+
+  Static guarantee: if the walker returns ``True``, the function
+  as expressed in this jaxpr is affine in ``theta``.  False
+  positives are possible only for adversarial implementations that
+  hide nonlinear ops behind data-dependent Python branches not
+  visible to JAX tracing.  Real-world moment functions are
+  essentially always cleanly expressed.
+
+- :func:`solve_linear_gmm`: closed-form solve when the moment is
+  affine, the manifold is Euclidean, and the weighting is data-
+  independent (i.e., not :class:`CUEWeighting`).
+
+- :func:`is_flat_manifold`: detect whether a
+  :class:`~manifoldgmm.geometry.Manifold` is Euclidean (the necessary
+  geometric condition for the closed-form path to apply).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+# jax's Var type moved around across versions; prefer the public
+# ``jax.extend.core.Var`` (jax >= 0.4.31) and fall back to the
+# private location for older releases.  In the worst case, we fall
+# back to duck-typing via ``hasattr(v, "count")``.
+_JaxVar: Any
+try:
+    from jax.extend.core import Var as _JaxVar
+except ImportError:  # pragma: no cover
+    try:
+        from jax._src.core import Var as _JaxVar
+    except ImportError:  # pragma: no cover
+        _JaxVar = None
+
+
+def _is_jax_var(v: Any) -> bool:
+    """True if ``v`` is a jaxpr Var (rather than a Literal)."""
+
+    if _JaxVar is not None:
+        return isinstance(v, _JaxVar)
+    return hasattr(v, "count")
+
+
+# JAX primitives that *preserve* affineness in their theta-derived
+# inputs.  Any primitive not on this list that touches theta-derived
+# variables causes the walker to reject the function as non-affine.
+_AFFINE_PRIMITIVES: frozenset[str] = frozenset(
+    {
+        # Pointwise affine ops
+        "add",
+        "sub",
+        "neg",
+        # Reshape / shape manipulation
+        "reshape",
+        "transpose",
+        "broadcast_in_dim",
+        "concatenate",
+        "slice",
+        "dynamic_slice",
+        "gather",
+        "squeeze",
+        # Linear contractions
+        "dot_general",
+        "reduce_sum",
+        "reduce_mean",
+        # Casting (changes dtype, preserves affineness)
+        "convert_element_type",
+        # Indexing primitives
+        "select_n",
+    }
+)
+
+
+def is_affine_in_theta(
+    moment_func: Any,
+    example_theta: jnp.ndarray,
+    example_data: Any,
+) -> bool:
+    """Static jaxpr-walker check for ``moment_func(theta, data)`` affine in ``theta``.
+
+    Returns ``True`` only if every JAX primitive that touches a
+    ``theta``-derived variable is in the affine whitelist (with
+    additional structural checks for ``mul`` and ``integer_pow`` that
+    can be affine *or* nonlinear depending on operand structure).
+
+    Parameters
+    ----------
+    moment_func:
+        Callable ``(theta, data) -> (N, k)``.
+    example_theta:
+        Any ``theta`` of the right shape; only used to trace the jaxpr.
+    example_data:
+        Any ``data`` of the right shape; only used to trace the jaxpr.
+
+    Returns
+    -------
+    bool
+        ``True`` iff the function as expressed in this jaxpr applies
+        only affine-preserving operations to ``theta``.
+    """
+
+    try:
+        closed = jax.make_jaxpr(moment_func)(example_theta, example_data)
+    except Exception:  # pragma: no cover - tracing failure
+        return False
+    return _jaxpr_affine_in_var(closed.jaxpr, closed.jaxpr.invars[0])
+
+
+def _jaxpr_affine_in_var(jaxpr: Any, target_var: Any) -> bool:
+    """Walk ``jaxpr`` and verify every op touching ``target_var`` is affine.
+
+    Recurses into sub-jaxprs (``scan``, ``cond``, ``while``, ``call_p``).
+    """
+
+    derived: set[Any] = {target_var}
+
+    for eqn in jaxpr.eqns:
+        invars_derived = [v for v in eqn.invars if _is_jax_var(v) and v in derived]
+        if not invars_derived:
+            continue
+
+        p = eqn.primitive.name
+
+        if p == "mul":
+            # Multiplication of a theta-derived variable by another
+            # variable is affine only if at most one operand is theta-
+            # derived.  Two theta-derived operands -> theta * theta ->
+            # nonlinear.
+            if len(invars_derived) > 1:
+                return False
+
+        elif p == "integer_pow":
+            # x ** k for integer k preserves affineness only when k == 1.
+            y = eqn.params.get("y", 1)
+            if y != 1:
+                return False
+
+        elif p in {"pjit", "custom_jvp_call", "custom_vjp_call_jaxpr"}:
+            # Recurse into the wrapped jaxpr.  Find the sub-jaxpr in
+            # the equation params and resolve which sub-invars
+            # correspond to theta-derived outer invars.
+            sub_jaxpr = _extract_sub_jaxpr(eqn.params)
+            if sub_jaxpr is None:
+                return False  # unknown wrapping; conservative reject
+            sub_targets = [
+                sub_jaxpr.invars[i]
+                for i, outer in enumerate(eqn.invars)
+                if _is_jax_var(outer) and outer in derived
+            ]
+            if not all(_jaxpr_affine_in_vars(sub_jaxpr, sub_targets) for _ in [0]):
+                return False
+
+        elif p == "cond":
+            # ``cond`` has true/false branches as sub-jaxprs in params.
+            branches = eqn.params.get("branches", ())
+            for branch in branches:
+                branch_jaxpr = getattr(branch, "jaxpr", branch)
+                sub_targets = [
+                    branch_jaxpr.invars[i]
+                    for i, outer in enumerate(eqn.invars[1:])  # skip predicate
+                    if _is_jax_var(outer) and outer in derived
+                ]
+                if not _jaxpr_affine_in_vars(branch_jaxpr, sub_targets):
+                    return False
+
+        elif p not in _AFFINE_PRIMITIVES:
+            return False
+
+        # Mark all outputs as theta-derived.
+        for outvar in eqn.outvars:
+            derived.add(outvar)
+
+    return True
+
+
+def _jaxpr_affine_in_vars(
+    jaxpr: Any,
+    target_vars: list[Any],
+) -> bool:
+    """Affineness in any of ``target_vars`` (sub-jaxpr helper)."""
+
+    derived: set[Any] = set(target_vars)
+    for eqn in jaxpr.eqns:
+        invars_derived = [v for v in eqn.invars if _is_jax_var(v) and v in derived]
+        if not invars_derived:
+            continue
+        p = eqn.primitive.name
+        if p == "mul" and len(invars_derived) > 1:
+            return False
+        if p == "integer_pow" and eqn.params.get("y", 1) != 1:
+            return False
+        if p not in _AFFINE_PRIMITIVES and p not in {
+            "mul",
+            "integer_pow",
+            "pjit",
+            "cond",
+        }:
+            return False
+        for outvar in eqn.outvars:
+            derived.add(outvar)
+    return True
+
+
+def _extract_sub_jaxpr(params: dict) -> Any | None:
+    """Pull a sub-jaxpr out of an equation's params dict (best effort)."""
+
+    for key in ("jaxpr", "call_jaxpr", "fun_jaxpr"):
+        if key in params:
+            obj = params[key]
+            return getattr(obj, "jaxpr", obj)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Closed-form solver
+# ---------------------------------------------------------------------------
+
+
+def is_flat_manifold(manifold: Any) -> bool:
+    """Check whether ``manifold`` is Euclidean (the geometric condition
+    for the closed-form GMM path to apply).
+
+    Recognizes :class:`pymanopt.manifolds.Euclidean` and products of
+    Euclideans.  Returns ``False`` for any curved manifold.
+    """
+
+    inner = getattr(manifold, "data", None)
+    if inner is None:
+        return False
+    try:
+        from pymanopt.manifolds import Euclidean, Product
+    except ImportError:  # pragma: no cover
+        return False
+    if isinstance(inner, Euclidean):
+        return True
+    if isinstance(inner, Product):
+        return all(isinstance(m, Euclidean) for m in inner.manifolds)
+    return False
+
+
+def affine_coefficients(
+    moment_func: Any,
+    example_theta: jnp.ndarray,
+    data: Any,
+) -> tuple[jnp.ndarray, jnp.ndarray]:
+    """Extract ``(a, B)`` such that ``g_bar(theta) = a + B @ theta``.
+
+    Computed via two autodiff queries on ``moment_func``:
+
+    - ``a = g_bar(0, data)`` (the constant term);
+    - ``B = jacobian(g_bar)(any theta)`` (constant when ``g`` is affine).
+
+    Sanity-check: numerically verifies that ``g_bar`` evaluated at
+    ``example_theta`` agrees with ``a + B @ example_theta`` to within
+    floating-point precision.  Raises ``ValueError`` if it doesn't,
+    which indicates the moment function isn't actually affine despite
+    user assertion / jaxpr-walker false positive.
+    """
+
+    p = example_theta.shape[0]
+    zero = jnp.zeros_like(example_theta)
+
+    def g_bar(theta):
+        return moment_func(theta, data).mean(axis=0)
+
+    a = g_bar(zero)
+    B = jax.jacfwd(g_bar)(zero)
+
+    # Sanity: g_bar(example_theta) == a + B @ example_theta?
+    predicted = a + B @ example_theta
+    actual = g_bar(example_theta)
+    residual = float(jnp.max(jnp.abs(predicted - actual)))
+    # Tolerance: scale with magnitude.  Allow a generous threshold
+    # since autodiff via float32 can accumulate noise.
+    a_scale = float(jnp.max(jnp.abs(a)))
+    b_scale = float(jnp.max(jnp.abs(B)))
+    scale = max(1.0, a_scale, b_scale)
+    if residual > 1e-6 * scale:
+        raise ValueError(
+            f"affine_coefficients: moment function does not behave "
+            f"affinely (g_bar deviates by {residual:.3g} from the "
+            f"inferred a + B @ theta at example_theta).  Re-check "
+            f"the moment function or set ``assume_linear=False``."
+        )
+    del p
+    return a, B
+
+
+def solve_linear_gmm(
+    moment_func: Any,
+    data: Any,
+    weighting_matrix: jnp.ndarray,
+    example_theta: jnp.ndarray,
+) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+    """Closed-form GMM for affine moment + Euclidean parameter space.
+
+    Solves ``theta_hat = -(B' W B)^{-1} B' W a`` where ``a = g_bar(0,
+    data)`` and ``B = d g_bar / d theta``.  Works for both just- and
+    over-identified problems as long as ``B'WB`` is non-singular.
+
+    Returns ``(theta_hat, a, B)`` so callers can also report the
+    residual ``g_bar(theta_hat) = a + B @ theta_hat`` and form the
+    final criterion ``g_bar' W g_bar`` themselves.
+    """
+
+    a, B = affine_coefficients(moment_func, example_theta, data)
+    BtW = B.T @ weighting_matrix
+    BtWB = BtW @ B
+    BtWa = BtW @ a
+    # Use solve for numerical stability over inv().
+    theta_hat = -jnp.linalg.solve(BtWB, BtWa)
+    return theta_hat, a, B
+
+
+def linear_gmm_diagnostics(
+    a: jnp.ndarray,
+    B: jnp.ndarray,
+    theta_hat: jnp.ndarray,
+    weighting_matrix: jnp.ndarray,
+) -> dict[str, float]:
+    """Compute the residual and criterion at a closed-form solution.
+
+    Useful for the ``verbosity`` report and as a sanity check that
+    the closed-form solution is consistent with the linear-moment
+    assumption.
+    """
+
+    g_bar_hat = a + B @ theta_hat
+    criterion = float(g_bar_hat @ weighting_matrix @ g_bar_hat)
+    residual_norm = float(jnp.linalg.norm(g_bar_hat))
+    return {
+        "criterion": criterion,
+        "g_bar_norm": residual_norm,
+    }
+
+
+__all__ = [
+    "is_affine_in_theta",
+    "is_flat_manifold",
+    "affine_coefficients",
+    "solve_linear_gmm",
+    "linear_gmm_diagnostics",
+]
+
+
+# Re-export for tests that need direct access to numpy-style result.
+def _to_numpy(x: jnp.ndarray) -> np.ndarray:
+    return np.asarray(x)

--- a/src/manifoldgmm/econometrics/gmm.py
+++ b/src/manifoldgmm/econometrics/gmm.py
@@ -2044,6 +2044,15 @@ class GMM:
         self._backend = "jax" if backend is GMM._BACKEND_UNSPECIFIED else backend
         self._cue_ridge = cue_ridge
         self._cue_target_condition = cue_target_condition
+        # Store the *uncoerced* weighting arg so :meth:`_with_dgp` can
+        # re-coerce against a sibling's MomentRestriction.  Data-
+        # dependent strategies like CUE bind to the restriction; if
+        # we reused the parent's coerced ``self._weighting`` in a
+        # sibling, the sibling would compute Omega-hat from the
+        # *parent's* data while optimizing over its own rebound data
+        # -- a bug that drives bootstrap fits to diverge on some
+        # replications.
+        self._weighting_arg = weighting
         self._weighting = self._coerce_weighting(weighting)
         self._optimizer = optimizer
         self._initial_point = initial_point
@@ -2446,7 +2455,10 @@ class GMM:
             dgp=dgp,
             manifold=self._manifold,
             backend=self._backend,
-            weighting=self._weighting,
+            # Pass the *uncoerced* weighting arg so the sibling
+            # constructs its own data-aware strategy (e.g.,
+            # CUEWeighting) bound to its own restriction.
+            weighting=self._weighting_arg,
             optimizer=self._optimizer,
             initial_point=self._initial_point,
             cue_ridge=self._cue_ridge,

--- a/src/manifoldgmm/econometrics/gmm.py
+++ b/src/manifoldgmm/econometrics/gmm.py
@@ -29,6 +29,15 @@ from ..geometry import Manifold, ManifoldPoint
 from ..optimizers import LoggingTrustRegions
 from .moment_restriction import MomentRestriction
 
+# v2 (DGP-based): a DataGeneratingProcess instance can be passed at
+# construction; see docs/design/v2_dgp.org.  Type imported lazily to
+# avoid creating a hard runtime coupling at module import time (the
+# v1 path -- ``GMM(restriction, ...)`` -- never imports dgp_protocol).
+try:  # pragma: no cover - import guard
+    from dgp_protocol import DataGeneratingProcess as _DGPProtocol
+except ImportError:  # pragma: no cover
+    _DGPProtocol = None
+
 # Default threshold for "tail_grad_slope ≈ 0".  Slope is in
 # log-gradient-norm per outer iteration; healthy convergence has slope
 # well below this (e.g., -0.5 near a quadratic optimum).  The
@@ -1895,13 +1904,70 @@ class Diagnostics:
         return out
 
 
+@dataclass
+class BootstrapResult:
+    """Result of :meth:`GMM.bootstrap`: the empirical distribution of theta.
+
+    v2 (DGP-based) raw-data bootstrap.  Each ``thetas[i]`` is a
+    :class:`~manifoldgmm.geometry.ManifoldPoint` from one refit on a
+    fresh ``dgp.draw()`` realization.
+
+    Attributes
+    ----------
+    thetas:
+        List of length ``B`` of refit parameter values.
+    base:
+        The :class:`GMM` instance that produced this bootstrap (kept
+        for the manifold / restriction context required by any
+        downstream tangent-space covariance computation).
+
+    Notes
+    -----
+    A manifold-aware tangent-space covariance and confidence-interval
+    machinery on top of ``thetas`` is intentionally not part of this
+    skeleton (see ``docs/design/v2_dgp.org``); add per-need in
+    follow-up PRs.  For Euclidean parameters, raw-array statistics
+    are straightforward:
+
+    >>> arr = np.stack([t.array for t in bs.thetas])    # shape (B, d)
+    >>> bs_mean = arr.mean(axis=0)
+    >>> bs_cov = np.cov(arr, rowvar=False, ddof=1)
+    """
+
+    thetas: list[Any]
+    base: GMM
+
+
 class GMM:
-    """High-level GMM estimator operating on a :class:`MomentRestriction`."""
+    """High-level GMM estimator operating on a :class:`MomentRestriction`.
+
+    Two construction routes:
+
+    - **v1**: ``GMM(restriction=MomentRestriction(g, X), ...)``.  Data
+      is bound inside the moment restriction; bit-identical to all
+      pre-v2 callers.
+    - **v2 (DGP-based)**: ``GMM(moment_func=g, dgp=my_dgp, ...)`` where
+      ``my_dgp`` conforms to
+      :class:`dgp_protocol.DataGeneratingProcess`.  The estimator
+      uses ``dgp.data`` for the point estimate and gains the
+      :meth:`bootstrap` method for DGP-driven raw-data bootstrap.
+
+    Exactly one route must be used per construction.  See
+    ``docs/design/v2_dgp.org`` for the full v2 design.
+    """
+
+    # Sentinel for the v2-only ``backend`` kwarg so we can detect
+    # whether the caller explicitly supplied it.
+    _BACKEND_UNSPECIFIED: object = object()
 
     def __init__(
         self,
-        restriction: MomentRestriction,
+        restriction: MomentRestriction | None = None,
         *,
+        moment_func: Callable[[Any, Any], Any] | None = None,
+        dgp: Any | None = None,
+        manifold: Manifold | None = None,
+        backend: Any = _BACKEND_UNSPECIFIED,
         weighting: WeightingStrategy | Callable[[Any], Any] | Any | None = None,
         optimizer: type[Optimizer] | Optimizer | None = None,
         initial_point: Any | None = None,
@@ -1909,7 +1975,59 @@ class GMM:
         cue_target_condition: float | None = None,
         penalty: PenaltyStrategy | Callable[[Any], Any] | None = None,
     ) -> None:
+        # v1 vs v2 path validation.
+        v2_inputs = (moment_func, dgp)
+        v2_supplied = any(x is not None for x in v2_inputs)
+        if restriction is not None and v2_supplied:
+            raise TypeError(
+                "GMM: pass either `restriction` (v1) or "
+                "(`moment_func`, `dgp`) (v2), not both."
+            )
+        if restriction is None:
+            if not all(x is not None for x in v2_inputs):
+                raise TypeError(
+                    "GMM: missing argument.  Provide either "
+                    "`restriction` (v1) or both `moment_func` and "
+                    "`dgp` (v2)."
+                )
+            if _DGPProtocol is not None and not isinstance(dgp, _DGPProtocol):
+                raise TypeError(
+                    f"GMM: `dgp` must satisfy the "
+                    f"dgp_protocol.DataGeneratingProcess Protocol; got "
+                    f"{type(dgp).__name__}."
+                )
+            # Synthesize a MomentRestriction bound to dgp.data.  ``g``
+            # is the vectorized moment function ``(theta, X) -> (N, k)``;
+            # ``manifold`` and ``backend`` are passed through so v2
+            # callers don't need to construct a MomentRestriction
+            # themselves.  Default backend is JAX (autodiff-capable).
+            effective_backend = (
+                "jax" if backend is GMM._BACKEND_UNSPECIFIED else backend
+            )
+            # Narrow ``dgp`` for the type-checker; the membership of
+            # ``v2_inputs`` was validated above.
+            assert dgp is not None
+            restriction = MomentRestriction(
+                g=moment_func,
+                data=dgp.data,
+                manifold=manifold,
+                backend=effective_backend,
+            )
+        elif manifold is not None or backend is not GMM._BACKEND_UNSPECIFIED:
+            # v1 path: backend / manifold are properties of the
+            # restriction.  Reject silent disagreement.
+            raise TypeError(
+                "GMM: `manifold` and `backend` are v2-only kwargs; v1 "
+                "callers should configure these on the MomentRestriction."
+            )
         self._restriction = restriction
+        # v2 attributes: ``self._dgp`` is None for v1 callers; non-None
+        # callers gain ``self.bootstrap(...)`` and DGP-aware inference.
+        self._dgp = dgp
+        self._moment_func = moment_func
+        # Stashed for _with_dgp (bootstrap rebuilds sibling GMMs).
+        self._manifold = manifold
+        self._backend = "jax" if backend is GMM._BACKEND_UNSPECIFIED else backend
         self._cue_ridge = cue_ridge
         self._cue_target_condition = cue_target_condition
         self._weighting = self._coerce_weighting(weighting)
@@ -1928,6 +2046,17 @@ class GMM:
     @property
     def moment_restriction(self) -> MomentRestriction:
         return self._restriction
+
+    @property
+    def dgp(self) -> Any | None:
+        """The :class:`dgp_protocol.DataGeneratingProcess`, or ``None``.
+
+        Non-None only when the GMM was constructed via the v2 path
+        (``moment_func=``, ``dgp=``).  v1-constructed callers
+        (``restriction=``) see ``None`` here.
+        """
+
+        return self._dgp
 
     def g_bar(self, theta: Any) -> Any:
         return self._restriction.g_bar(theta)
@@ -2230,6 +2359,86 @@ class GMM:
         )
         _maybe_warn_optimizer_health(result)
         return result
+
+    # ------------------------------------------------------------------
+    # v2: DGP-driven bootstrap
+    # ------------------------------------------------------------------
+    def bootstrap(
+        self,
+        B: int,
+        *,
+        seed: int | None = None,
+        **estimate_kwargs: Any,
+    ) -> BootstrapResult:
+        """Refit on ``B`` fresh draws from ``self.dgp``.
+
+        Available only when the GMM was constructed via the v2 path
+        (``moment_func=``, ``dgp=``).  v1-constructed GMMs (which have
+        no DGP) raise :class:`RuntimeError`.
+
+        Parameters
+        ----------
+        B:
+            Number of bootstrap replications.
+        seed:
+            Optional integer seed for the bootstrap's own RNG (used to
+            spawn one child Generator per replication).  ``None``
+            (default) draws from system entropy -- pass an int for a
+            reproducible bootstrap.  The bootstrap RNG is independent
+            of the DGP's own RNG.
+        **estimate_kwargs:
+            Forwarded to :meth:`estimate` on each bootstrap replication.
+
+        Returns
+        -------
+        BootstrapResult
+            Holds the ``B`` refit ``theta`` values.
+        """
+
+        if self._dgp is None or self._moment_func is None:
+            raise RuntimeError(
+                "GMM.bootstrap requires the v2 construction path "
+                "(`moment_func=`, `dgp=`); this GMM was constructed "
+                "via `restriction=` and has no DGP attached."
+            )
+        if B < 1:
+            raise ValueError(f"B must be >= 1; got {B}.")
+        # Bootstrap-side RNG: independent of the DGP's stream so the
+        # call doesn't reach into the DGP's private attributes.  Pass
+        # ``seed=`` for reproducibility.
+        parent_rng = np.random.default_rng(seed)
+        children = [self._dgp.with_rng(s) for s in parent_rng.spawn(B)]
+        thetas: list[Any] = []
+        for child in children:
+            # Each replication: child draws once; the draw becomes the
+            # child's bound data; we build a sibling GMM on that
+            # rebound DGP and refit.
+            rebound = child.with_data(child.draw())
+            sibling = self._with_dgp(rebound)
+            thetas.append(sibling.estimate(**estimate_kwargs).theta)
+        return BootstrapResult(thetas=thetas, base=self)
+
+    def _with_dgp(self, dgp: Any) -> GMM:
+        """Construct a sibling GMM bound to a different DGP.
+
+        Internal helper for :meth:`bootstrap`; the new GMM shares the
+        v2 moment function, weighting, optimizer, initial point,
+        CUE knobs, and penalty.  The restriction is rebuilt on
+        ``dgp.data``.
+        """
+
+        return GMM(
+            moment_func=self._moment_func,
+            dgp=dgp,
+            manifold=self._manifold,
+            backend=self._backend,
+            weighting=self._weighting,
+            optimizer=self._optimizer,
+            initial_point=self._initial_point,
+            cue_ridge=self._cue_ridge,
+            cue_target_condition=self._cue_target_condition,
+            penalty=self._penalty,
+        )
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/src/manifoldgmm/econometrics/gmm.py
+++ b/src/manifoldgmm/econometrics/gmm.py
@@ -388,6 +388,19 @@ class CUEWeighting:
         }
 
 
+def _weighting_is_theta_independent(weighting: WeightingStrategy) -> bool:
+    """True iff the weighting matrix is independent of ``theta``.
+
+    Recognised theta-independent: :class:`FixedWeighting` (and its
+    :class:`IdentityWeighting` subclass).  Anything else -- including
+    :class:`CUEWeighting` and :class:`CallableWeighting` -- is
+    conservatively treated as theta-dependent.  Theta-independent
+    weighting is a precondition for the closed-form GMM path.
+    """
+
+    return isinstance(weighting, FixedWeighting)
+
+
 class IdentityWeighting(FixedWeighting):
     """Identity matrix weighting used for first-stage two-step GMM."""
 
@@ -1974,6 +1987,9 @@ class GMM:
         cue_ridge: float = 0.0,
         cue_target_condition: float | None = None,
         penalty: PenaltyStrategy | Callable[[Any], Any] | None = None,
+        assume_linear: bool = False,
+        detect_linear: bool = True,
+        verbosity: int = 0,
     ) -> None:
         # v1 vs v2 path validation.
         v2_inputs = (moment_func, dgp)
@@ -2044,6 +2060,20 @@ class GMM:
         self._backend = "jax" if backend is GMM._BACKEND_UNSPECIFIED else backend
         self._cue_ridge = cue_ridge
         self._cue_target_condition = cue_target_condition
+        # Linear-fast-path knobs.
+        # - ``assume_linear``: user asserts the moment is affine in
+        #   theta; framework trusts and short-circuits to closed form
+        #   (with a sanity check).
+        # - ``detect_linear``: attempt a static jaxpr-walker check at
+        #   construction time; if it succeeds, use closed form.
+        # - ``verbosity``: 0 = silent (default); 1 = report linearity
+        #   autodetection; higher = more.
+        self._assume_linear = assume_linear
+        self._detect_linear = detect_linear
+        self._verbosity = verbosity
+        # Cached linearity status; set on first estimate() call.
+        # ``None`` means "not yet determined."
+        self._linearity_status: bool | None = None
         # Store the *uncoerced* weighting arg so :meth:`_with_dgp` can
         # re-coerce against a sibling's MomentRestriction.  Data-
         # dependent strategies like CUE bind to the restriction; if
@@ -2249,6 +2279,14 @@ class GMM:
         if theta_start is None:
             raise ValueError("Provide an initial_point to start the optimisation.")
 
+        # Linear-fast-path: warm-start the optimizer at the
+        # closed-form solution when the moment is affine in theta,
+        # the manifold is flat (Euclidean), the weighting is data-
+        # independent, and no penalty is configured.  See
+        # ``_linearity.py`` and the ``assume_linear`` /
+        # ``detect_linear`` / ``verbosity`` constructor kwargs.
+        theta_start = self._maybe_closed_form_warmstart(theta_start)
+
         optimizer_kwargs = dict(optimizer_kwargs or {})
         if verbose is not None and "verbosity" not in optimizer_kwargs:
             if isinstance(verbose, bool):
@@ -2441,6 +2479,128 @@ class GMM:
             thetas.append(sibling.estimate(**estimate_kwargs).theta)
         return BootstrapResult(thetas=thetas, base=self)
 
+    # ------------------------------------------------------------------
+    # Linear-fast-path helpers
+    # ------------------------------------------------------------------
+    def _maybe_closed_form_warmstart(self, theta_start: Any) -> Any:
+        """Return ``theta_start`` (closed-form solution if applicable).
+
+        Eligibility for the closed-form warm start:
+
+        - Constructed via v2 path (we need ``moment_func``);
+        - ``assume_linear=True`` *or* the jaxpr walker accepts the
+          moment as affine in theta (``detect_linear=True``);
+        - Manifold is flat (Euclidean or product of Euclideans);
+        - Weighting matrix is theta-independent (i.e., not
+          :class:`CUEWeighting` and not a user-supplied callable
+          whose theta-dependence we can't introspect);
+        - No penalty is configured.
+
+        On a successful match, computes ``theta_hat = -(B' W B)^-1
+        B' W a`` and returns it as the optimizer's starting point.
+        The optimizer typically converges in 0-1 iterations from
+        this warm start.  On any failure (sanity check trips,
+        singular Hessian, etc.), returns the original ``theta_start``
+        unchanged and the iterative path runs as usual.
+        """
+
+        # v2-only: need moment_func.
+        if self._moment_func is None:
+            return theta_start
+
+        if not (self._assume_linear or self._detect_linear):
+            return theta_start
+
+        # Quick eligibility filters that don't require any jaxpr work.
+        if self._penalty is not None:
+            return theta_start
+        if not _weighting_is_theta_independent(self._weighting):
+            return theta_start
+
+        from ..geometry import ManifoldPoint as _MP
+        from ._linearity import (
+            is_affine_in_theta,
+            is_flat_manifold,
+            linear_gmm_diagnostics,
+            solve_linear_gmm,
+        )
+
+        if self._manifold is None or not is_flat_manifold(self._manifold):
+            return theta_start
+
+        # Determine linearity (cached for bootstrap repeated calls).
+        if self._linearity_status is None:
+            if self._assume_linear:
+                self._linearity_status = True
+                if self._verbosity >= 1:
+                    print(
+                        "GMM: linearity asserted by `assume_linear=True`; "
+                        "using closed-form warm start."
+                    )
+            else:
+                # Run the jaxpr walker against the current data.
+                example_theta = self._to_array(theta_start)
+                example_data = self._restriction._data
+                try:
+                    is_lin = is_affine_in_theta(
+                        self._moment_func, example_theta, example_data
+                    )
+                except Exception:  # pragma: no cover
+                    is_lin = False
+                self._linearity_status = bool(is_lin)
+                if is_lin and self._verbosity >= 1:
+                    print(
+                        "GMM: linear moment in theta detected (jaxpr "
+                        "walker); using closed-form warm start."
+                    )
+
+        if not self._linearity_status:
+            return theta_start
+
+        # Extract the constant weighting matrix.  For
+        # ``IdentityWeighting`` / ``FixedWeighting`` this just returns
+        # the stored matrix; the call is cheap.
+        W = self._weighting.matrix(theta_start)
+        W_arr = jnp.asarray(W)
+
+        try:
+            theta_hat_arr, a, B = solve_linear_gmm(
+                self._moment_func,
+                self._restriction._data,
+                W_arr,
+                self._to_array(theta_start),
+            )
+        except (ValueError, np.linalg.LinAlgError) as exc:
+            if self._verbosity >= 1:
+                print(
+                    f"GMM: closed-form solve failed ({exc!s}); "
+                    f"falling back to iterative."
+                )
+            return theta_start
+
+        if self._verbosity >= 2:
+            diag = linear_gmm_diagnostics(a, B, theta_hat_arr, W_arr)
+            print(
+                f"GMM: closed-form theta_hat = "
+                f"{np.asarray(theta_hat_arr)}, "
+                f"||g_bar|| = {diag['g_bar_norm']:.3g}, "
+                f"criterion = {diag['criterion']:.3g}"
+            )
+
+        # Wrap the array as a ManifoldPoint so downstream code (the
+        # optimizer initialization) sees a properly-typed start.
+        return _MP(value=np.asarray(theta_hat_arr), manifold=self._manifold)
+
+    @staticmethod
+    def _to_array(point: Any) -> jnp.ndarray:
+        """Coerce a ManifoldPoint / ambient value to a JAX 1-D array."""
+
+        from ..geometry import ManifoldPoint as _MP
+
+        if isinstance(point, _MP):
+            return jnp.asarray(point.value)
+        return jnp.asarray(point)
+
     def _with_dgp(self, dgp: Any) -> GMM:
         """Construct a sibling GMM bound to a different DGP.
 
@@ -2464,6 +2624,12 @@ class GMM:
             cue_ridge=self._cue_ridge,
             cue_target_condition=self._cue_target_condition,
             penalty=self._penalty,
+            assume_linear=self._assume_linear,
+            detect_linear=self._detect_linear,
+            # Bootstrap replications inherit the parent's linearity
+            # status (no need to re-detect per replication); pass
+            # verbosity=0 to siblings to avoid spamming the log.
+            verbosity=0,
         )
 
     # ------------------------------------------------------------------

--- a/src/manifoldgmm/econometrics/gmm.py
+++ b/src/manifoldgmm/econometrics/gmm.py
@@ -1996,6 +1996,23 @@ class GMM:
                     f"dgp_protocol.DataGeneratingProcess Protocol; got "
                     f"{type(dgp).__name__}."
                 )
+            # Narrow ``dgp`` for the type-checker; the membership of
+            # ``v2_inputs`` was validated above.
+            assert dgp is not None
+            # The DGP must carry an observed realization for the point
+            # estimate to be well-defined.  Pure-parametric DGPs
+            # constructed without an ``observation=`` arg (e.g., the
+            # fair-coin example in DGP_Protocol/examples/) have
+            # ``dgp.data is None`` and must be bound to a draw before
+            # the GMM is constructed.
+            if dgp.data is None:
+                raise ValueError(
+                    "GMM v2: `dgp.data` is None -- the DGP has no "
+                    "observed realization bound.  Bind one before "
+                    "constructing the GMM, e.g.:\n"
+                    "    bound = my_dgp.with_data(my_dgp.draw())\n"
+                    "    gmm = GMM(moment_func=g, dgp=bound, ...)"
+                )
             # Synthesize a MomentRestriction bound to dgp.data.  ``g``
             # is the vectorized moment function ``(theta, X) -> (N, k)``;
             # ``manifold`` and ``backend`` are passed through so v2
@@ -2004,9 +2021,6 @@ class GMM:
             effective_backend = (
                 "jax" if backend is GMM._BACKEND_UNSPECIFIED else backend
             )
-            # Narrow ``dgp`` for the type-checker; the membership of
-            # ``v2_inputs`` was validated above.
-            assert dgp is not None
             restriction = MomentRestriction(
                 g=moment_func,
                 data=dgp.data,

--- a/src/manifoldgmm/econometrics/gmm.py
+++ b/src/manifoldgmm/econometrics/gmm.py
@@ -2279,13 +2279,15 @@ class GMM:
         if theta_start is None:
             raise ValueError("Provide an initial_point to start the optimisation.")
 
-        # Linear-fast-path: warm-start the optimizer at the
-        # closed-form solution when the moment is affine in theta,
-        # the manifold is flat (Euclidean), the weighting is data-
-        # independent, and no penalty is configured.  See
-        # ``_linearity.py`` and the ``assume_linear`` /
+        # Linear-fast-path: detect / assert linearity once for this
+        # estimate() call (cached on ``self``).  Per-stage closed-form
+        # dispatch happens inside :meth:`_run_stage`, which fires for
+        # each stage whose weighting is theta-independent.  This
+        # handles 1-step, two-step, and iterated linear GMM: each
+        # stage is a single matrix solve instead of a trust-region
+        # loop.  See ``_linearity.py`` and the ``assume_linear`` /
         # ``detect_linear`` / ``verbosity`` constructor kwargs.
-        theta_start = self._maybe_closed_form_warmstart(theta_start)
+        self._maybe_detect_linearity(theta_start)
 
         optimizer_kwargs = dict(optimizer_kwargs or {})
         if verbose is not None and "verbosity" not in optimizer_kwargs:
@@ -2482,114 +2484,157 @@ class GMM:
     # ------------------------------------------------------------------
     # Linear-fast-path helpers
     # ------------------------------------------------------------------
-    def _maybe_closed_form_warmstart(self, theta_start: Any) -> Any:
-        """Return ``theta_start`` (closed-form solution if applicable).
+    def _maybe_detect_linearity(self, theta_sample: Any) -> None:
+        """Determine linearity status (cached) and report at ``verbosity>=1``.
 
-        Eligibility for the closed-form warm start:
+        Caches ``self._linearity_status`` so bootstrap replications
+        (which share this GMM instance via :meth:`_with_dgp`) do not
+        re-run the jaxpr walker on every refit.
 
-        - Constructed via v2 path (we need ``moment_func``);
-        - ``assume_linear=True`` *or* the jaxpr walker accepts the
-          moment as affine in theta (``detect_linear=True``);
-        - Manifold is flat (Euclidean or product of Euclideans);
-        - Weighting matrix is theta-independent (i.e., not
-          :class:`CUEWeighting` and not a user-supplied callable
-          whose theta-dependence we can't introspect);
-        - No penalty is configured.
+        Eligibility filters that knock out linearity *regardless* of
+        the moment function:
 
-        On a successful match, computes ``theta_hat = -(B' W B)^-1
-        B' W a`` and returns it as the optimizer's starting point.
-        The optimizer typically converges in 0-1 iterations from
-        this warm start.  On any failure (sanity check trips,
-        singular Hessian, etc.), returns the original ``theta_start``
-        unchanged and the iterative path runs as usual.
+        - Not constructed via the v2 path (no ``moment_func``);
+        - Penalty configured (the closed-form path assumes a pure
+          quadratic criterion);
+        - Manifold is not flat (Riemannian Newton would be needed
+          instead -- not implemented).
+
+        These filters cause :meth:`_try_closed_form_stage` to return
+        ``None`` for every stage; the iterative path runs as usual.
         """
 
-        # v2-only: need moment_func.
+        if self._linearity_status is not None:
+            return  # already determined this session
+
+        # Eligibility filters that don't require any jaxpr work.
         if self._moment_func is None:
-            return theta_start
-
+            self._linearity_status = False
+            return
         if not (self._assume_linear or self._detect_linear):
-            return theta_start
-
-        # Quick eligibility filters that don't require any jaxpr work.
+            self._linearity_status = False
+            return
         if self._penalty is not None:
-            return theta_start
-        if not _weighting_is_theta_independent(self._weighting):
-            return theta_start
+            self._linearity_status = False
+            return
 
-        from ..geometry import ManifoldPoint as _MP
-        from ._linearity import (
-            is_affine_in_theta,
-            is_flat_manifold,
-            linear_gmm_diagnostics,
-            solve_linear_gmm,
-        )
+        from ._linearity import is_affine_in_theta, is_flat_manifold
 
         if self._manifold is None or not is_flat_manifold(self._manifold):
-            return theta_start
+            self._linearity_status = False
+            return
 
-        # Determine linearity (cached for bootstrap repeated calls).
-        if self._linearity_status is None:
-            if self._assume_linear:
-                self._linearity_status = True
-                if self._verbosity >= 1:
-                    print(
-                        "GMM: linearity asserted by `assume_linear=True`; "
-                        "using closed-form warm start."
-                    )
-            else:
-                # Run the jaxpr walker against the current data.
-                example_theta = self._to_array(theta_start)
-                example_data = self._restriction._data
-                try:
-                    is_lin = is_affine_in_theta(
-                        self._moment_func, example_theta, example_data
-                    )
-                except Exception:  # pragma: no cover
-                    is_lin = False
-                self._linearity_status = bool(is_lin)
-                if is_lin and self._verbosity >= 1:
-                    print(
-                        "GMM: linear moment in theta detected (jaxpr "
-                        "walker); using closed-form warm start."
-                    )
+        if self._assume_linear:
+            self._linearity_status = True
+            if self._verbosity >= 1:
+                print(
+                    "GMM: linearity asserted by `assume_linear=True`; "
+                    "using closed-form per-stage solves where possible."
+                )
+            return
+
+        # ``detect_linear``: run the jaxpr walker.
+        example_theta = self._to_array(theta_sample)
+        example_data = self._restriction._data
+        try:
+            is_lin = is_affine_in_theta(self._moment_func, example_theta, example_data)
+        except Exception:  # pragma: no cover
+            is_lin = False
+        self._linearity_status = bool(is_lin)
+        if is_lin and self._verbosity >= 1:
+            print(
+                "GMM: linear moment in theta detected (jaxpr walker); "
+                "using closed-form per-stage solves where possible."
+            )
+
+    def _try_closed_form_stage(
+        self, initial_point: Any, weighting: WeightingStrategy
+    ) -> _StageResult | None:
+        """Solve one GMM stage in closed form, or return ``None`` to fall back.
+
+        Eligibility per stage (the cross-cutting filters from
+        :meth:`_maybe_detect_linearity` are baked into
+        ``self._linearity_status``):
+
+        - ``self._linearity_status`` is ``True``;
+        - This stage's ``weighting`` is theta-independent (i.e.,
+          :class:`FixedWeighting` -- including the
+          :class:`IdentityWeighting` subclass).  ``CUEWeighting``
+          and bare ``CallableWeighting`` skip the fast path because
+          their criterion is not quadratic in ``theta``.
+
+        For two-step / iterated GMM this method fires *per stage*:
+        stage 1 (identity-weighted) and stage 2
+        (``FixedWeighting(Omega^-1)`` from stage-1 residuals) each
+        get one matrix solve instead of a trust-region loop.  This
+        is the closed-form 2-step / 3SLS-equivalent path for
+        over-identified linear moments.
+        """
 
         if not self._linearity_status:
-            return theta_start
+            return None
+        if not _weighting_is_theta_independent(weighting):
+            return None
+        # All other eligibility filters (penalty, manifold, v2-only)
+        # are already absorbed into ``self._linearity_status``.
 
-        # Extract the constant weighting matrix.  For
-        # ``IdentityWeighting`` / ``FixedWeighting`` this just returns
-        # the stored matrix; the call is cheap.
-        W = self._weighting.matrix(theta_start)
-        W_arr = jnp.asarray(W)
+        from ..geometry import ManifoldPoint as _MP
+        from ._linearity import solve_linear_gmm
+
+        # ``weighting`` is FixedWeighting (or its subclass); calling
+        # ``.matrix(theta)`` returns the stored matrix regardless of
+        # theta.  Use the initial point as a placeholder.
+        W_arr = jnp.asarray(weighting.matrix(initial_point))
 
         try:
             theta_hat_arr, a, B = solve_linear_gmm(
                 self._moment_func,
                 self._restriction._data,
                 W_arr,
-                self._to_array(theta_start),
+                self._to_array(initial_point),
             )
         except (ValueError, np.linalg.LinAlgError) as exc:
             if self._verbosity >= 1:
                 print(
                     f"GMM: closed-form solve failed ({exc!s}); "
-                    f"falling back to iterative."
+                    f"falling back to optimizer for this stage."
                 )
-            return theta_start
+            return None
+
+        # Wrap and build the _StageResult.  ``self._manifold`` is
+        # non-None whenever ``self._linearity_status is True``
+        # (verified inside ``_maybe_detect_linearity``).
+        assert self._manifold is not None
+        theta_hat_np = np.asarray(theta_hat_arr)
+        theta_point = _MP(value=theta_hat_np, manifold=self._manifold)
+        g_bar_hat = self._restriction.g_bar(theta_point)
+        g_bar_arr = np.asarray(g_bar_hat, dtype=float)
+        cost_val = float(g_bar_arr @ np.asarray(W_arr, dtype=float) @ g_bar_arr)
+        grad_norm = float(np.linalg.norm(g_bar_arr))
 
         if self._verbosity >= 2:
-            diag = linear_gmm_diagnostics(a, B, theta_hat_arr, W_arr)
             print(
-                f"GMM: closed-form theta_hat = "
-                f"{np.asarray(theta_hat_arr)}, "
-                f"||g_bar|| = {diag['g_bar_norm']:.3g}, "
-                f"criterion = {diag['criterion']:.3g}"
+                f"GMM stage closed-form: theta_hat = {theta_hat_np}, "
+                f"||g_bar|| = {grad_norm:.3g}, cost = {cost_val:.3g}"
             )
 
-        # Wrap the array as a ManifoldPoint so downstream code (the
-        # optimizer initialization) sees a properly-typed start.
-        return _MP(value=np.asarray(theta_hat_arr), manifold=self._manifold)
+        optimizer_report = {
+            "iterations": 0,
+            "stopping_criterion": "closed-form linear GMM",
+            "converged": True,
+            "cost": cost_val,
+            "gradient_norm": grad_norm,
+            "step_size": 0.0,
+            "cost_evaluations": 1,
+            "time": 0.0,
+            "log": None,
+        }
+        return _StageResult(
+            theta=theta_point,
+            g_bar=g_bar_hat,
+            weighting=weighting,
+            optimizer_report=optimizer_report,
+        )
 
     @staticmethod
     def _to_array(point: Any) -> jnp.ndarray:
@@ -2719,6 +2764,19 @@ class GMM:
         weighting: WeightingStrategy,
         optimizer_kwargs: Mapping[str, Any],
     ) -> _StageResult:
+        # Linear-fast-path: if the moment is affine in theta and
+        # this stage's weighting is theta-independent, the GMM
+        # criterion at this stage is a quadratic form and the
+        # minimiser has the closed form
+        # ``theta_hat = -(B' W B)^{-1} B' W a``.  For two-step /
+        # iterated GMM this fires per stage, so both the identity-
+        # weighted first stage and the ``FixedWeighting(Omega^-1)``
+        # second stage become single matrix solves -- the closed-
+        # form 2-step / 3SLS-equivalent path.
+        closed_form = self._try_closed_form_stage(initial_point, weighting)
+        if closed_form is not None:
+            return closed_form
+
         cost = self._build_cost(weighting)
         manifold_wrapper = self._restriction.manifold
         if manifold_wrapper is None or manifold_wrapper.data is None:

--- a/tests/v2/bernoulli_v2.py
+++ b/tests/v2/bernoulli_v2.py
@@ -1,0 +1,157 @@
+"""Bernoulli v2 GMM example: estimate ``p`` from fair-coin draws.
+
+End-to-end demonstration of the v2 ManifoldGMM API (``GMM(moment_func,
+dgp, ...)``) consuming the ``fair_coin`` ``ParametricDGP`` from the
+sibling DGP_Protocol repo.
+
+The model is ``X_i ~ Bernoulli(p)`` with ``p in [0, 1]``.  The moment
+condition
+
+    E[X - p] = 0
+
+is just-identified (one parameter, one moment), so the GMM analog
+estimator coincides with the sample mean of the observed
+realization.  The example illustrates:
+
+- Constructing a v2 GMM on a DGP that arrives pre-bound to an
+  observation (see ``../DGP_Protocol/examples/fair_coin.py``).
+- Computing the point estimate via :meth:`GMM.estimate`.
+- Running a parametric bootstrap via :meth:`GMM.bootstrap` -- each
+  replication draws afresh from the original ``fair_coin``
+  generator (i.e., from ``Bernoulli(0.5)``).
+- Computing the analytic Wald-style standard error
+  ``SE = sqrt(p_hat * (1 - p_hat) / N)`` and a two-sided test of
+  ``H_0: p = 0.5``.
+
+Run directly::
+
+    python tests/v2/bernoulli_v2.py
+
+Or load into IPython::
+
+    %run tests/v2/bernoulli_v2.py
+"""
+
+from __future__ import annotations
+
+import sys
+import warnings
+from pathlib import Path
+
+import jax.numpy as jnp
+import numpy as np
+
+# Suppress pymanopt's trust-region RuntimeWarning that fires when a
+# step converges in a single inner iteration (the trust-region
+# acceptance ratio degenerates to 0/0).  Harmless for this 1-D linear
+# moment condition; otherwise dominates the bootstrap output.
+warnings.filterwarnings(
+    "ignore",
+    category=RuntimeWarning,
+    message="invalid value encountered in scalar divide",
+)
+
+# The fair_coin example lives in the sibling DGP_Protocol repo,
+# which is not on the import path by default.  This file lives at
+# ``tests/v2/bernoulli_v2.py``; resolve up to the parent of the
+# ManifoldGMM repo root and then over into ``DGP_Protocol/examples``.
+_DGP_EXAMPLES = Path(__file__).resolve().parents[3] / "DGP_Protocol" / "examples"
+if str(_DGP_EXAMPLES) not in sys.path:
+    sys.path.insert(0, str(_DGP_EXAMPLES))
+from fair_coin import dgp as fair_coin_dgp  # noqa: E402
+from manifoldgmm import GMM, Manifold  # noqa: E402
+from pymanopt.manifolds import Euclidean  # noqa: E402
+
+
+# --------------------------------------------------------------------------
+# Moment condition
+# --------------------------------------------------------------------------
+def g(p, data):
+    """Bernoulli location moment ``g(p, X) = X - p``.
+
+    Broadcasts scalar ``p`` over rows of ``data`` of shape ``(N, 1)``.
+    Returns shape ``(N, 1)`` of per-row contributions; the GMM forms
+    ``g_bar(p) = (1/N) sum_i g_i(p)`` internally.
+    """
+
+    return data - p
+
+
+# --------------------------------------------------------------------------
+# End-to-end run
+# --------------------------------------------------------------------------
+def run() -> dict[str, float]:
+    """Run the example end-to-end and return summary statistics.
+
+    Returns a dict with ``p_hat``, ``analytic_se``, ``bootstrap_mean``,
+    ``bootstrap_se``, and ``wald_z``.  Useful for tests.
+    """
+
+    obs = np.asarray(fair_coin_dgp.data)
+    N = obs.shape[0]
+    print(f"observed realization:   shape={obs.shape}  dtype={obs.dtype}")
+    print(f"empirical mean:         {float(obs.mean()):.4f}  (analog estimator)")
+    print()
+
+    # Manifold: p as an unconstrained Euclidean coordinate.  The
+    # moment-condition root lies in (0, 1) so the bound is non-binding
+    # for non-degenerate Bernoulli data.
+    M = Manifold.from_pymanopt(Euclidean(1))
+
+    gmm = GMM(
+        moment_func=g,
+        dgp=fair_coin_dgp,
+        manifold=M,
+        initial_point=jnp.array([0.5]),
+    )
+
+    # Point estimate.  ``verbosity=0`` silences the per-iteration
+    # optimizer chatter (uninformative for a 1-d just-identified
+    # problem; would dominate the bootstrap output otherwise).
+    quiet = {"verbosity": 0}
+    result = gmm.estimate(optimizer_kwargs=quiet)
+    p_hat = float(np.asarray(result.theta_array)[0])
+    print(f"GMM v2 estimate:        p_hat = {p_hat:.6f}")
+    print("  (just-identified -> matches the empirical mean to " "optimizer tolerance)")
+    print()
+
+    # Analytic SE for the Bernoulli mean.
+    analytic_se = float(np.sqrt(p_hat * (1.0 - p_hat) / N))
+    print(
+        f"analytic SE:            {analytic_se:.4f}  "
+        f"(sqrt(p_hat * (1 - p_hat) / N), N = {N})"
+    )
+
+    # Parametric bootstrap: each replication draws from the original
+    # fair_coin generator (Bernoulli(0.5)), refits, returns p_b.
+    B = 500
+    print(f"parametric bootstrap:   B={B}, seed=42 ...")
+    bs = gmm.bootstrap(B=B, seed=42, optimizer_kwargs=quiet)
+    p_bs = np.array([float(np.asarray(t.value)[0]) for t in bs.thetas])
+    bootstrap_mean = float(p_bs.mean())
+    bootstrap_se = float(p_bs.std(ddof=1))
+    print(f"  bootstrap mean:       {bootstrap_mean:.4f}")
+    print(f"  bootstrap SE:         {bootstrap_se:.4f}")
+    print()
+
+    # Wald-style two-sided test of H_0: p = 0.5.  Under the null,
+    # z ~ N(0, 1) asymptotically.
+    z = (p_hat - 0.5) / analytic_se
+    print("Wald test of H_0: p = 0.5")
+    print(f"  z = (p_hat - 0.5) / SE = {z:+.3f}")
+    verdict = "reject" if abs(z) > 1.96 else "accept"
+    print(
+        f"  two-sided, alpha=0.05: {verdict}  (|z| {'>' if abs(z) > 1.96 else '<='} 1.96)"
+    )
+
+    return {
+        "p_hat": p_hat,
+        "analytic_se": analytic_se,
+        "bootstrap_mean": bootstrap_mean,
+        "bootstrap_se": bootstrap_se,
+        "wald_z": z,
+    }
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/v2/gaussian_mixture_v2.py
+++ b/tests/v2/gaussian_mixture_v2.py
@@ -1,0 +1,244 @@
+"""Gaussian-mixture v2 GMM example: nonlinear moments via coin_plus_noise.
+
+Generalization of :file:`bernoulli_v2.py` to a two-component Gaussian
+mixture with the *means fixed* at 0 and 1 (matching the
+``coin_plus_noise`` DGP structure) and *three estimated parameters*::
+
+    Y_i ~ p * N(1, sigma_1^2) + (1 - p) * N(0, sigma_0^2)
+
+The truth under ``../DGP_Protocol/examples/coin_plus_noise.py`` is
+``p = 0.5``, ``sigma_0 = sigma_1 = 1`` (Y is a 50/50 mixture of
+N(0, 1) and N(1, 1), so E[Y] = 0.5 and Var[Y] = 1.25).
+
+Moment conditions (k = 4, p = 3, ``df = 1`` for the J-statistic)::
+
+    m_1 = E[Y]   = p
+    m_2 = E[Y^2] = p (1 + sigma_1^2) + (1 - p) sigma_0^2
+    m_3 = E[Y^3] = p (1 + 3 sigma_1^2)
+    m_4 = E[Y^4] = p (1 + 6 sigma_1^2 + 3 sigma_1^4)
+                  + (1 - p) 3 sigma_0^4
+
+Identification: m_1 pins down ``p``; m_3 pins down ``sigma_1`` given
+``p``; m_2 pins down ``sigma_0`` given ``p`` and ``sigma_1``; m_4 is
+the over-identifying restriction.  Unlike the Bernoulli example,
+the moments are *nonlinear* in ``sigma_0`` and ``sigma_1`` so the
+GMM machinery does real work.
+
+Parameterization
+----------------
+The natural parameter space ``(p, sigma_0, sigma_1) in (0, 1) x R+
+x R+`` is reparameterized to unconstrained Euclidean(3)::
+
+    theta = [logit_p, log_v_0, log_v_1]
+    p     = sigmoid(theta[0])
+    v_j   = exp(theta[j+1])  (= sigma_j^2 -- variance, not std)
+
+We parameterize the *variance* (v_j = sigma_j^2) rather than the
+std because the moment equations depend on sigma_j only through
+sigma_j^2; parameterizing the variance dodges the (sigma, -sigma)
+sign ambiguity that an unconstrained ``Euclidean(3)`` on raw
+``sigma_j`` would expose.
+
+Run directly::
+
+    python tests/v2/gaussian_mixture_v2.py
+
+Or load into IPython::
+
+    %run tests/v2/gaussian_mixture_v2.py
+"""
+
+from __future__ import annotations
+
+import sys
+import warnings
+from pathlib import Path
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+# Suppress pymanopt's harmless trust-region degenerate-step
+# RuntimeWarning that fires whenever a step converges in one inner
+# iteration (the trust-region tau ratio becomes 0/0).
+warnings.filterwarnings(
+    "ignore",
+    category=RuntimeWarning,
+    message="invalid value encountered in scalar divide",
+)
+
+# The coin_plus_noise example lives in the sibling DGP_Protocol
+# repo.  Internally it does ``from examples.fair_coin import ...``,
+# so ``DGP_Protocol/`` (the parent of ``examples/``) must be on
+# ``sys.path`` for the ``examples`` package to resolve.  We also put
+# ``examples/`` itself on the path so the top-level module name
+# ``coin_plus_noise`` is importable directly.
+#
+# Defensive: ManifoldGMM has its own (empty) ``examples`` package at
+# its root, which shadows DGP_Protocol's.  Drop any stale ``examples``
+# from ``sys.modules`` and insert DGP_Protocol's paths at the head of
+# ``sys.path`` so its ``examples`` wins.
+_DGP_ROOT = Path(__file__).resolve().parents[3] / "DGP_Protocol"
+_DGP_EXAMPLES = _DGP_ROOT / "examples"
+for _stale in [m for m in sys.modules if m == "examples" or m.startswith("examples.")]:
+    del sys.modules[_stale]
+for _path in (_DGP_EXAMPLES, _DGP_ROOT):
+    str_path = str(_path)
+    # Reinsert at position 0 even if already present, so DGP_Protocol
+    # outranks ManifoldGMM-rooted candidates added by pytest.
+    while str_path in sys.path:
+        sys.path.remove(str_path)
+    sys.path.insert(0, str_path)
+from coin_plus_noise import dgp as mixture_dgp  # noqa: E402
+from manifoldgmm import GMM, Manifold  # noqa: E402
+from pymanopt.manifolds import Euclidean  # noqa: E402
+
+
+# --------------------------------------------------------------------------
+# Reparameterization helpers
+# --------------------------------------------------------------------------
+def _unpack(theta: jnp.ndarray) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+    """Map unconstrained ``theta in R^3`` to ``(p, v_0, v_1)``."""
+
+    p = jax.nn.sigmoid(theta[0])
+    v_0 = jnp.exp(theta[1])
+    v_1 = jnp.exp(theta[2])
+    return p, v_0, v_1
+
+
+# --------------------------------------------------------------------------
+# Moment conditions (vectorized over rows of data)
+# --------------------------------------------------------------------------
+def g(theta: jnp.ndarray, data: jnp.ndarray) -> jnp.ndarray:
+    """Per-row contributions to four moment conditions, shape ``(N, 4)``.
+
+    ``data`` has shape ``(N, 1)``; flatten to ``(N,)`` for elementwise
+    power operations.
+    """
+
+    p, v_0, v_1 = _unpack(theta)
+    # Implied population moments under the mixture model.
+    m_1 = p
+    m_2 = p * (1.0 + v_1) + (1.0 - p) * v_0
+    m_3 = p * (1.0 + 3.0 * v_1)
+    m_4 = p * (1.0 + 6.0 * v_1 + 3.0 * v_1**2) + (1.0 - p) * 3.0 * v_0**2
+
+    y = data[:, 0]
+    return jnp.stack(
+        [
+            y - m_1,
+            y**2 - m_2,
+            y**3 - m_3,
+            y**4 - m_4,
+        ],
+        axis=1,
+    )
+
+
+# --------------------------------------------------------------------------
+# End-to-end run
+# --------------------------------------------------------------------------
+def run() -> dict[str, float]:
+    """Run the example end-to-end and return summary statistics.
+
+    Returns a dict with reparameterized estimates plus the recovered
+    natural parameters ``p``, ``sigma_0``, ``sigma_1`` and the
+    realized empirical moments.  Useful for the smoke test.
+    """
+
+    obs = np.asarray(mixture_dgp.data, dtype=float)
+    N = obs.shape[0]
+    y = obs[:, 0]
+
+    print(f"observed realization:   shape={obs.shape}  " f"dtype={obs.dtype}")
+    emp_m = [float((y**k).mean()) for k in (1, 2, 3, 4)]
+    print(
+        "empirical moments:      "
+        f"m1={emp_m[0]:.4f}  m2={emp_m[1]:.4f}  "
+        f"m3={emp_m[2]:.4f}  m4={emp_m[3]:.4f}"
+    )
+    print(
+        "model truth:            m1=0.5000  m2=1.5000  "
+        "m3=2.0000  m4=6.5000  (p=0.5, sigma_0=sigma_1=1)"
+    )
+    print()
+
+    M = Manifold.from_pymanopt(Euclidean(3))
+    # Initial point: theta = (0, 0, 0) <-> (p=0.5, v_0=v_1=1), the
+    # truth under coin_plus_noise.
+    theta_0 = jnp.zeros(3)
+
+    gmm = GMM(
+        moment_func=g,
+        dgp=mixture_dgp,
+        manifold=M,
+        initial_point=theta_0,
+    )
+
+    # Two-step GMM: start with identity weighting, re-weight with the
+    # inverse moment covariance at the first-step estimate.
+    quiet = {"verbosity": 0}
+    result = gmm.estimate(two_step=True, optimizer_kwargs=quiet)
+    theta_hat = np.asarray(result.theta_array)
+    p_hat, v0_hat, v1_hat = (
+        float(1.0 / (1.0 + np.exp(-theta_hat[0]))),
+        float(np.exp(theta_hat[1])),
+        float(np.exp(theta_hat[2])),
+    )
+    s0_hat = float(np.sqrt(v0_hat))
+    s1_hat = float(np.sqrt(v1_hat))
+
+    print("two-step GMM estimates:")
+    print(f"  theta (raw)         = {theta_hat}")
+    print(f"  p_hat               = {p_hat:.4f}     (true 0.5)")
+    print(f"  sigma_0_hat         = {s0_hat:.4f}     (true 1.0)")
+    print(f"  sigma_1_hat         = {s1_hat:.4f}     (true 1.0)")
+    print()
+
+    # J-statistic of overidentification.  Under H_0 (model correct)
+    # and the optimal weighting, the criterion at the optimum is
+    # asymptotically chi^2 with df = k - p = 4 - 3 = 1.
+    j_stat = float(result.criterion_value)
+    print(f"Hansen J-statistic:     J = {j_stat:.4f}  (df = 1)")
+    print(
+        "  asymptotic critical chi^2(1) at alpha=0.05 is 3.841; "
+        f"{'reject' if j_stat > 3.841 else 'accept'}"
+    )
+    print()
+
+    # Parametric bootstrap to give a sanity SE on p_hat.  Each
+    # replication draws fresh from the original coin_plus_noise DGP,
+    # refits.  Small B since each refit is a 3-D nonlinear GMM.
+    B = 80
+    print(f"parametric bootstrap:   B={B}, seed=42 ...")
+    bs = gmm.bootstrap(B=B, seed=42, two_step=True, optimizer_kwargs=quiet)
+    p_bs = np.array(
+        [float(1.0 / (1.0 + np.exp(-float(np.asarray(t.value)[0])))) for t in bs.thetas]
+    )
+    s0_bs = np.array(
+        [float(np.sqrt(np.exp(float(np.asarray(t.value)[1])))) for t in bs.thetas]
+    )
+    s1_bs = np.array(
+        [float(np.sqrt(np.exp(float(np.asarray(t.value)[2])))) for t in bs.thetas]
+    )
+    print(f"  p:       mean = {p_bs.mean():.4f}     SE = {p_bs.std(ddof=1):.4f}")
+    print(f"  sigma_0: mean = {s0_bs.mean():.4f}     SE = {s0_bs.std(ddof=1):.4f}")
+    print(f"  sigma_1: mean = {s1_bs.mean():.4f}     SE = {s1_bs.std(ddof=1):.4f}")
+
+    return {
+        "p_hat": p_hat,
+        "sigma_0_hat": s0_hat,
+        "sigma_1_hat": s1_hat,
+        "j_stat": j_stat,
+        "bootstrap_p_mean": float(p_bs.mean()),
+        "bootstrap_p_se": float(p_bs.std(ddof=1)),
+        "bootstrap_sigma0_mean": float(s0_bs.mean()),
+        "bootstrap_sigma0_se": float(s0_bs.std(ddof=1)),
+        "bootstrap_sigma1_mean": float(s1_bs.mean()),
+        "bootstrap_sigma1_se": float(s1_bs.std(ddof=1)),
+        "n_obs": N,
+    }
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/v2/test_bernoulli_v2.py
+++ b/tests/v2/test_bernoulli_v2.py
@@ -1,0 +1,75 @@
+"""Smoke test for the end-to-end :file:`tests/v2/bernoulli_v2.py` demo.
+
+Verifies that the v2 GMM machinery produces statistically sensible
+output on the fair-coin Bernoulli example: the point estimate matches
+the empirical mean, the bootstrap SE matches the analytic SE to
+within Monte Carlo error, and the Wald z lies in the asymptotic
+acceptance region for the (true) null ``p = 0.5``.
+
+This is intentionally a *behavioral* test, not a pinned-output test
+-- the bootstrap is seeded but the test asserts on intervals so the
+v2 inference plumbing can evolve without breaking the test for
+trivial reasons.
+
+The smoke test exercises:
+
+- v2 ``GMM(moment_func, dgp, manifold, ...)`` construction on a
+  pre-bound ``ParametricDGP``;
+- :meth:`GMM.estimate` on a just-identified problem;
+- :meth:`GMM.bootstrap` over 500 parametric resamples;
+- Bootstrap-vs-analytic SE agreement to within MC tolerance.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make the sibling ``bernoulli_v2`` module (this directory) importable
+# from inside the test without relying on package-relative imports.
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+# Skip cleanly if the sibling DGP_Protocol/examples isn't reachable
+# (e.g., the bernoulli_v2 module fails to import its fair_coin DGP).
+bernoulli_v2 = pytest.importorskip(
+    "bernoulli_v2",
+    reason=(
+        "tests/v2/bernoulli_v2.py requires " "../DGP_Protocol/examples/fair_coin.py"
+    ),
+)
+
+
+def test_bernoulli_end_to_end_run(capsys: pytest.CaptureFixture[str]) -> None:
+    """End-to-end smoke: point estimate, bootstrap, Wald test agree."""
+
+    stats = bernoulli_v2.run()
+    # Captured stdout is informational; the assertions below carry
+    # the semantic guarantees.
+    captured = capsys.readouterr()
+    assert "p_hat" in captured.out
+    assert "bootstrap mean" in captured.out
+    assert "Wald test" in captured.out
+
+    # The bound observation has 51 heads out of 100 (seed 2026 in
+    # DGP_Protocol/examples/fair_coin.py).  The just-identified GMM
+    # estimator equals the empirical mean to optimizer tolerance.
+    assert stats["p_hat"] == pytest.approx(0.51, abs=1e-4)
+
+    # Analytic Bernoulli SE: sqrt(p_hat * (1 - p_hat) / N), N = 100.
+    assert stats["analytic_se"] == pytest.approx(0.05, abs=5e-4)
+
+    # Bootstrap should converge to the truth (0.5) under the
+    # parametric DGP and produce SE close to the analytic value.
+    # Tolerances are loose enough to absorb MC variation across
+    # numpy / pymanopt / jax versions while still catching gross
+    # plumbing breakage.
+    assert stats["bootstrap_mean"] == pytest.approx(0.5, abs=0.02)
+    assert stats["bootstrap_se"] == pytest.approx(stats["analytic_se"], abs=0.015)
+
+    # Wald z for the fair-coin null: the observed mean of 0.51 lies
+    # well within the 95% acceptance region.
+    assert abs(stats["wald_z"]) < 1.96

--- a/tests/v2/test_dgp_e2e.py
+++ b/tests/v2/test_dgp_e2e.py
@@ -1,0 +1,229 @@
+"""End-to-end test for the v2 (DGP-based) GMM construction path.
+
+Covers:
+
+- Point estimate agreement between the v1 (``restriction=``) and v2
+  (``moment_func=``, ``dgp=``) construction routes on a small
+  Gaussian location problem.
+- v2 mutual exclusivity: passing both ``restriction=`` and
+  ``moment_func=`` raises; passing neither raises.
+- ``gmm.bootstrap(B)`` runs on a v2-constructed GMM, returns ``B``
+  refit theta values within a sensible distance of the empirical
+  mean.
+- ``gmm.bootstrap(B)`` on a v1-constructed GMM raises ``RuntimeError``
+  (no DGP is attached).
+
+These tests use the standard JAX backend so the GMM optimizer can
+autodiff through the moment function.  The DGP carries the data as
+a JAX array (``EmpiricalDGP(observation=jnp.array(...))``); ``data``
+flows through unchanged.
+
+See ``docs/design/v2_dgp.org`` for the full v2 design.
+"""
+
+from __future__ import annotations
+
+import dgp_protocol as dp
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from manifoldgmm import GMM, Manifold, MomentRestriction
+from pymanopt.manifolds import Euclidean
+
+
+def _location_g(theta, data):
+    """Vectorized location moment ``g(theta, X) = X - theta``.
+
+    JAX-compatible; broadcasts ``theta`` of shape ``(p,)`` over rows
+    of ``data`` of shape ``(N, p)``.  Returns shape ``(N, p)``.
+    """
+
+    return data - theta[None, :]
+
+
+def _build_dataset(seed: int = 0) -> jnp.ndarray:
+    rng = np.random.default_rng(seed)
+    return jnp.asarray(rng.standard_normal(size=(200, 3)))
+
+
+def _build_manifold() -> Manifold:
+    return Manifold.from_pymanopt(Euclidean(3))
+
+
+# ---------------------------------------------------------------------------
+# Construction errors
+# ---------------------------------------------------------------------------
+def test_v2_requires_both_moment_func_and_dgp() -> None:
+    """Passing only ``moment_func=`` (or only ``dgp=``) raises."""
+
+    dgp = dp.EmpiricalDGP(observation=_build_dataset())
+    with pytest.raises(TypeError, match="missing argument"):
+        GMM(moment_func=_location_g)
+    with pytest.raises(TypeError, match="missing argument"):
+        GMM(dgp=dgp)
+
+
+def test_rejects_both_restriction_and_v2_kwargs() -> None:
+    """Passing both v1 and v2 inputs raises."""
+
+    X = _build_dataset()
+    M = _build_manifold()
+    r = MomentRestriction(g=_location_g, data=X, manifold=M, backend="jax")
+    dgp = dp.EmpiricalDGP(observation=X)
+    with pytest.raises(TypeError, match="either"):
+        GMM(restriction=r, moment_func=_location_g, dgp=dgp)
+
+
+def test_rejects_non_dgp_object_in_dgp_kwarg() -> None:
+    """``dgp=`` must satisfy the DataGeneratingProcess Protocol."""
+
+    with pytest.raises(TypeError, match="DataGeneratingProcess"):
+        GMM(moment_func=_location_g, dgp="not a dgp")
+
+
+def test_rejects_v2_only_kwargs_with_restriction() -> None:
+    """``manifold=`` / ``backend=`` are v2-only; v1 callers must use MR."""
+
+    X = _build_dataset()
+    M = _build_manifold()
+    r = MomentRestriction(g=_location_g, data=X, manifold=M, backend="jax")
+    with pytest.raises(TypeError, match="v2-only"):
+        GMM(restriction=r, manifold=M)
+    with pytest.raises(TypeError, match="v2-only"):
+        GMM(restriction=r, backend="numpy")
+
+
+# ---------------------------------------------------------------------------
+# Point estimate equivalence: v1 vs v2
+# ---------------------------------------------------------------------------
+def test_v1_and_v2_point_estimates_agree_on_iid_data() -> None:
+    """v2-constructed GMM produces the same theta_hat as v1 on iid data."""
+
+    X = _build_dataset(seed=0)
+    M = _build_manifold()
+    theta_0 = jnp.zeros(3)
+
+    # v1 path: data bound in the MomentRestriction.
+    r1 = MomentRestriction(g=_location_g, data=X, manifold=M, backend="jax")
+    gmm_v1 = GMM(r1, initial_point=theta_0)
+    result_v1 = gmm_v1.estimate()
+
+    # v2 path: data via an EmpiricalDGP.
+    dgp = dp.EmpiricalDGP(observation=X, seed=0)
+    gmm_v2 = GMM(
+        moment_func=_location_g,
+        dgp=dgp,
+        manifold=M,
+        backend="jax",
+        initial_point=theta_0,
+    )
+    result_v2 = gmm_v2.estimate()
+
+    np.testing.assert_allclose(
+        np.asarray(result_v1.theta_array, dtype=float),
+        np.asarray(result_v2.theta_array, dtype=float),
+        atol=1e-8,
+    )
+
+
+def test_v2_dgp_property_exposes_dgp() -> None:
+    """The v2 GMM exposes ``gmm.dgp``; v1 GMM returns ``None``."""
+
+    X = _build_dataset()
+    M = _build_manifold()
+    dgp = dp.EmpiricalDGP(observation=X, seed=0)
+
+    gmm_v2 = GMM(
+        moment_func=_location_g,
+        dgp=dgp,
+        manifold=M,
+        initial_point=jnp.zeros(3),
+    )
+    assert gmm_v2.dgp is dgp
+
+    r = MomentRestriction(g=_location_g, data=X, manifold=M, backend="jax")
+    gmm_v1 = GMM(r, initial_point=jnp.zeros(3))
+    assert gmm_v1.dgp is None
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap
+# ---------------------------------------------------------------------------
+def test_bootstrap_runs_and_returns_b_replications() -> None:
+    """``gmm.bootstrap(B)`` returns a BootstrapResult holding B refits."""
+
+    X = _build_dataset(seed=0)
+    M = _build_manifold()
+    dgp = dp.EmpiricalDGP(observation=X, seed=0)
+    gmm = GMM(
+        moment_func=_location_g,
+        dgp=dgp,
+        manifold=M,
+        initial_point=jnp.zeros(3),
+    )
+
+    B = 4
+    bs = gmm.bootstrap(B=B, seed=42)
+    assert len(bs.thetas) == B
+    assert bs.base is gmm
+    # Each refit lies within a small multiple of the bootstrap SE of
+    # the empirical mean.
+    X_np = np.asarray(X, dtype=float)
+    emp_mean = X_np.mean(axis=0)
+    emp_se = X_np.std(axis=0, ddof=1) / np.sqrt(X_np.shape[0])
+    for theta_b in bs.thetas:
+        arr = np.asarray(theta_b.value, dtype=float)
+        assert np.all(np.abs(arr - emp_mean) < 6.0 * emp_se), (
+            f"bootstrap refit theta={arr} too far from empirical "
+            f"mean={emp_mean} (se={emp_se})"
+        )
+
+
+def test_bootstrap_is_reproducible_under_seed() -> None:
+    """Two bootstrap calls with the same seed produce identical refits."""
+
+    X = _build_dataset(seed=0)
+    M = _build_manifold()
+
+    def _build_gmm() -> GMM:
+        # Fresh DGP each time so the DGP's own RNG is identical.
+        return GMM(
+            moment_func=_location_g,
+            dgp=dp.EmpiricalDGP(observation=X, seed=0),
+            manifold=M,
+            initial_point=jnp.zeros(3),
+        )
+
+    bs_a = _build_gmm().bootstrap(B=3, seed=11)
+    bs_b = _build_gmm().bootstrap(B=3, seed=11)
+    for ta, tb in zip(bs_a.thetas, bs_b.thetas, strict=True):
+        np.testing.assert_array_equal(
+            np.asarray(ta.value, dtype=float),
+            np.asarray(tb.value, dtype=float),
+        )
+
+
+def test_bootstrap_raises_on_v1_constructed_gmm() -> None:
+    """A GMM built with only ``restriction=`` has no DGP; bootstrap raises."""
+
+    X = _build_dataset()
+    M = _build_manifold()
+    r = MomentRestriction(g=_location_g, data=X, manifold=M, backend="jax")
+    gmm = GMM(r, initial_point=jnp.zeros(3))
+    with pytest.raises(RuntimeError, match="v2"):
+        gmm.bootstrap(B=2)
+
+
+def test_bootstrap_validates_B() -> None:
+    """B must be positive."""
+
+    M = _build_manifold()
+    dgp = dp.EmpiricalDGP(observation=_build_dataset())
+    gmm = GMM(
+        moment_func=_location_g,
+        dgp=dgp,
+        manifold=M,
+        initial_point=jnp.zeros(3),
+    )
+    with pytest.raises(ValueError, match="B must be >= 1"):
+        gmm.bootstrap(B=0)

--- a/tests/v2/test_dgp_e2e.py
+++ b/tests/v2/test_dgp_e2e.py
@@ -81,6 +81,52 @@ def test_rejects_non_dgp_object_in_dgp_kwarg() -> None:
         GMM(moment_func=_location_g, dgp="not a dgp")
 
 
+def test_rejects_dgp_with_no_bound_data() -> None:
+    """A pure-parametric DGP with ``data is None`` raises a clear error.
+
+    Mirrors the fair_coin example in ``DGP_Protocol/examples/``: the
+    DGP is constructed with ``observation=None`` (no realization
+    yet).  The v2 GMM needs a bound realization for the point
+    estimate, so we refuse with a hint pointing at
+    ``dgp.with_data(dgp.draw())``.
+    """
+
+    def gen(rng, shape):
+        return rng.standard_normal(shape)
+
+    pure_param = dp.ParametricDGP(generator=gen, default_shape=(50, 3), seed=0)
+    assert pure_param.data is None  # sanity for the test premise
+
+    with pytest.raises(ValueError, match="with_data"):
+        GMM(
+            moment_func=_location_g,
+            dgp=pure_param,
+            manifold=_build_manifold(),
+            initial_point=jnp.zeros(3),
+        )
+
+
+def test_accepts_pure_parametric_dgp_after_with_data() -> None:
+    """The same DGP, bound to a draw, constructs cleanly."""
+
+    def gen(rng, shape):
+        return rng.standard_normal(shape)
+
+    pure_param = dp.ParametricDGP(generator=gen, default_shape=(50, 3), seed=0)
+    bound = pure_param.with_data(pure_param.draw())
+    assert bound.data is not None
+
+    gmm = GMM(
+        moment_func=_location_g,
+        dgp=bound,
+        manifold=_build_manifold(),
+        initial_point=jnp.zeros(3),
+    )
+    # And the estimate runs.
+    result = gmm.estimate()
+    assert result.theta_array is not None
+
+
 def test_rejects_v2_only_kwargs_with_restriction() -> None:
     """``manifold=`` / ``backend=`` are v2-only; v1 callers must use MR."""
 

--- a/tests/v2/test_gaussian_mixture_v2.py
+++ b/tests/v2/test_gaussian_mixture_v2.py
@@ -1,0 +1,78 @@
+"""Smoke test for :file:`tests/v2/gaussian_mixture_v2.py`.
+
+Verifies that the v2 GMM machinery handles a *nonlinear*
+moment-condition problem (two-step GMM with 4 moments for 3
+parameters, ``df = 1``) on the upstream ``coin_plus_noise`` DGP:
+
+- The point estimate ``(p_hat, sigma_0_hat, sigma_1_hat)`` lies in a
+  sensible neighbourhood of the truth ``(0.5, 1.0, 1.0)`` -- loose
+  bands because ``N = 100`` and three parameters with an
+  empirically-skewed realization yield real estimation error.
+- The Hansen J-statistic accepts the (correctly-specified) model at
+  the asymptotic 5% level.
+- The parametric bootstrap's means concentrate near the truth and
+  produce non-trivial standard errors.
+
+As with :file:`test_bernoulli_v2.py`, this is a *behavioral* test
+with tolerance bands sized to absorb MC variation while still
+catching gross plumbing regressions.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make the sibling ``gaussian_mixture_v2`` module importable from
+# inside the test without relying on package-relative imports.
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+gaussian_mixture_v2 = pytest.importorskip(
+    "gaussian_mixture_v2",
+    reason=(
+        "tests/v2/gaussian_mixture_v2.py requires "
+        "../DGP_Protocol/examples/coin_plus_noise.py"
+    ),
+)
+
+
+def test_gaussian_mixture_end_to_end_run(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """End-to-end smoke: point estimates, J-stat, bootstrap behaviour."""
+
+    stats = gaussian_mixture_v2.run()
+    captured = capsys.readouterr()
+    assert "two-step GMM estimates" in captured.out
+    assert "J-statistic" in captured.out
+    assert "parametric bootstrap" in captured.out
+
+    # Point estimates land in a wide neighbourhood of the truth.
+    # N=100 with three parameters yields ~10-20% error on this DGP
+    # for any single realization; loosen bands accordingly.
+    assert 0.30 <= stats["p_hat"] <= 0.70
+    assert 0.7 <= stats["sigma_0_hat"] <= 1.4
+    assert 0.7 <= stats["sigma_1_hat"] <= 1.6
+
+    # J-stat: the model is correctly specified, so J should be well
+    # under chi^2_1(0.95) = 3.84.  Allow some slack to accommodate
+    # the optimal-weighting variability at N=100.
+    assert stats["j_stat"] < 5.0
+    assert stats["j_stat"] >= 0.0
+
+    # Parametric bootstrap should concentrate near the truth.  The
+    # original DGP has p=0.5 and sigma_0=sigma_1=1 -- the bootstrap
+    # samples from the true generator (not from the empirical
+    # distribution), so the means should converge there.
+    assert stats["bootstrap_p_mean"] == pytest.approx(0.5, abs=0.06)
+    assert stats["bootstrap_sigma0_mean"] == pytest.approx(1.0, abs=0.15)
+    assert stats["bootstrap_sigma1_mean"] == pytest.approx(1.0, abs=0.15)
+
+    # Bootstrap SEs are non-trivial and not absurd.
+    assert 0.01 < stats["bootstrap_p_se"] < 0.3
+    assert 0.01 < stats["bootstrap_sigma0_se"] < 0.4
+    assert 0.01 < stats["bootstrap_sigma1_se"] < 0.4

--- a/tests/v2/test_linearity.py
+++ b/tests/v2/test_linearity.py
@@ -1,0 +1,342 @@
+"""Tests for the linearity autodetection and closed-form GMM path.
+
+Covers:
+
+- :func:`is_affine_in_theta` correctly classifies linear vs nonlinear
+  moment functions (including JAX-numerical-derivative blind-spots
+  like the bump function constructed via ``jax.lax.cond``).
+- ``assume_linear=True`` short-circuits jaxpr-walker; raises clear
+  error when the assertion is wrong (sanity check trips).
+- ``detect_linear=True`` (the default) autodetects via jaxpr.
+- ``detect_linear=False`` suppresses detection.
+- ``verbosity=1`` reports linearity status to stdout.
+- The closed-form warm start produces the right point estimate on
+  linear-moment problems with ``IdentityWeighting``.
+- The fast path is correctly skipped on nonlinear-moment problems
+  and on CUE-weighted problems (which can't be expressed as
+  closed-form).
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import dgp_protocol as dp
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from manifoldgmm import GMM, Manifold, MomentRestriction
+from manifoldgmm.econometrics._linearity import (
+    affine_coefficients,
+    is_affine_in_theta,
+    is_flat_manifold,
+    solve_linear_gmm,
+)
+from manifoldgmm.econometrics.gmm import (
+    CUEWeighting,
+    FixedWeighting,
+    IdentityWeighting,
+    _weighting_is_theta_independent,
+)
+from pymanopt.manifolds import Euclidean, Sphere
+
+warnings.filterwarnings(
+    "ignore",
+    category=RuntimeWarning,
+    message="invalid value encountered in scalar divide",
+)
+
+
+# --------------------------------------------------------------------------
+# is_affine_in_theta: linear and nonlinear cases
+# --------------------------------------------------------------------------
+def _g_linear(theta, data):
+    """Linear in theta: g(theta, X) = X - theta."""
+
+    return data - theta
+
+
+def _g_quadratic(theta, data):
+    """Nonlinear in theta: g(theta, X) = X - theta**2."""
+
+    return data - theta**2
+
+
+def _g_exp(theta, data):
+    """Nonlinear in theta: g(theta, X) = X - exp(theta)."""
+
+    return data - jnp.exp(theta)
+
+
+def _g_matmul_linear(theta, data):
+    """Linear in theta via matmul: g(theta, X) = X - theta[None, :].
+
+    data has shape (N, p); theta has shape (p,); result has shape (N, p).
+    Exercises matmul/broadcast paths in the jaxpr walker.
+    """
+
+    return data - theta[None, :]
+
+
+def _make_panel(N: int = 20) -> jnp.ndarray:
+    rng = np.random.default_rng(0)
+    return jnp.asarray(rng.standard_normal(size=(N, 1)))
+
+
+def test_jaxpr_walker_detects_linear() -> None:
+    data = _make_panel()
+    assert is_affine_in_theta(_g_linear, jnp.array([0.5]), data) is True
+
+
+def test_jaxpr_walker_detects_quadratic_nonlinear() -> None:
+    data = _make_panel()
+    assert is_affine_in_theta(_g_quadratic, jnp.array([0.5]), data) is False
+
+
+def test_jaxpr_walker_detects_exp_nonlinear() -> None:
+    data = _make_panel()
+    assert is_affine_in_theta(_g_exp, jnp.array([0.5]), data) is False
+
+
+def test_jaxpr_walker_detects_matmul_linear() -> None:
+    """Multi-d linear moment: matmul of theta-derived var with a constant."""
+
+    data = jnp.asarray(np.random.default_rng(0).standard_normal(size=(20, 3)))
+    assert (
+        is_affine_in_theta(_g_matmul_linear, jnp.array([0.1, 0.2, 0.3]), data) is True
+    )
+
+
+# --------------------------------------------------------------------------
+# is_flat_manifold
+# --------------------------------------------------------------------------
+def test_is_flat_manifold_euclidean() -> None:
+    M = Manifold.from_pymanopt(Euclidean(3))
+    assert is_flat_manifold(M) is True
+
+
+def test_is_flat_manifold_sphere() -> None:
+    M = Manifold.from_pymanopt(Sphere(3))
+    assert is_flat_manifold(M) is False
+
+
+def test_is_flat_manifold_none() -> None:
+    assert is_flat_manifold(None) is False
+
+
+# --------------------------------------------------------------------------
+# Closed-form solver
+# --------------------------------------------------------------------------
+def test_affine_coefficients_extracts_a_and_B() -> None:
+    """``affine_coefficients`` recovers ``a`` and ``B`` for a linear moment."""
+
+    data = _make_panel()
+    a, B = affine_coefficients(_g_linear, jnp.array([0.5]), data)
+    # Linear: a = g_bar(0) = data.mean(); B = -1.
+    np.testing.assert_allclose(float(a[0]), float(data.mean()), atol=1e-6)
+    np.testing.assert_allclose(float(B[0, 0]), -1.0, atol=1e-6)
+
+
+def test_affine_coefficients_raises_on_nonlinear() -> None:
+    """Sanity check trips when the moment isn't actually affine."""
+
+    data = _make_panel()
+    with pytest.raises(ValueError, match="affinely"):
+        affine_coefficients(_g_quadratic, jnp.array([0.5]), data)
+
+
+def test_solve_linear_gmm_matches_analog() -> None:
+    """Closed-form solve recovers the empirical mean for the location model."""
+
+    data = _make_panel()
+    W = jnp.eye(1)
+    theta_hat, a, B = solve_linear_gmm(_g_linear, data, W, jnp.array([0.5]))
+    np.testing.assert_allclose(float(theta_hat[0]), float(data.mean()), atol=1e-6)
+
+
+# --------------------------------------------------------------------------
+# _weighting_is_theta_independent
+# --------------------------------------------------------------------------
+def test_identity_weighting_is_theta_independent() -> None:
+    assert _weighting_is_theta_independent(IdentityWeighting(3)) is True
+
+
+def test_fixed_weighting_is_theta_independent() -> None:
+    W = FixedWeighting(np.eye(3))
+    assert _weighting_is_theta_independent(W) is True
+
+
+def test_cue_weighting_is_theta_dependent() -> None:
+    # CUEWeighting depends on theta via the restriction.
+    rest = MomentRestriction(g=_g_linear, data=_make_panel())
+    assert _weighting_is_theta_independent(CUEWeighting(rest)) is False
+
+
+# --------------------------------------------------------------------------
+# GMM integration: warm start fires when applicable
+# --------------------------------------------------------------------------
+def test_gmm_uses_closed_form_on_linear_with_identity_weighting(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Verbosity=1 reports the autodetected closed-form warm start."""
+
+    data = _make_panel()
+    dgp = dp.EmpiricalDGP(observation=data, seed=0)
+    M = Manifold.from_pymanopt(Euclidean(1))
+    gmm = GMM(
+        moment_func=_g_linear,
+        dgp=dgp,
+        manifold=M,
+        initial_point=jnp.zeros(1),
+        weighting=IdentityWeighting(1),
+        verbosity=1,
+    )
+    gmm.estimate(optimizer_kwargs={"verbosity": 0})
+    captured = capsys.readouterr()
+    assert "linear moment in theta detected" in captured.out
+
+
+def test_gmm_assume_linear_short_circuits(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``assume_linear=True`` skips the walker and reports the assertion."""
+
+    data = _make_panel()
+    dgp = dp.EmpiricalDGP(observation=data, seed=0)
+    M = Manifold.from_pymanopt(Euclidean(1))
+    gmm = GMM(
+        moment_func=_g_linear,
+        dgp=dgp,
+        manifold=M,
+        initial_point=jnp.zeros(1),
+        weighting=IdentityWeighting(1),
+        verbosity=1,
+        assume_linear=True,
+    )
+    gmm.estimate(optimizer_kwargs={"verbosity": 0})
+    captured = capsys.readouterr()
+    assert "asserted by `assume_linear=True`" in captured.out
+
+
+def test_gmm_detect_linear_off_is_silent(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``detect_linear=False`` produces no linearity message."""
+
+    data = _make_panel()
+    dgp = dp.EmpiricalDGP(observation=data, seed=0)
+    M = Manifold.from_pymanopt(Euclidean(1))
+    gmm = GMM(
+        moment_func=_g_linear,
+        dgp=dgp,
+        manifold=M,
+        initial_point=jnp.zeros(1),
+        weighting=IdentityWeighting(1),
+        verbosity=1,
+        detect_linear=False,
+    )
+    gmm.estimate(optimizer_kwargs={"verbosity": 0})
+    captured = capsys.readouterr()
+    assert "linear moment" not in captured.out
+    assert "asserted by" not in captured.out
+
+
+def test_gmm_skips_fast_path_for_nonlinear_moment(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Nonlinear moment is correctly identified; no warm-start message."""
+
+    rng = np.random.default_rng(0)
+    # Generate data consistent with g_quadratic = X - theta^2 = 0,
+    # i.e., X = theta_true^2 + noise.
+    theta_true = 0.7
+    data = jnp.asarray(theta_true**2 + rng.standard_normal(size=(50, 1)) * 0.1)
+    dgp = dp.EmpiricalDGP(observation=data, seed=0)
+    M = Manifold.from_pymanopt(Euclidean(1))
+    gmm = GMM(
+        moment_func=_g_quadratic,
+        dgp=dgp,
+        manifold=M,
+        initial_point=jnp.array([0.5]),
+        weighting=IdentityWeighting(1),
+        verbosity=1,
+    )
+    gmm.estimate(optimizer_kwargs={"verbosity": 0})
+    captured = capsys.readouterr()
+    assert "linear moment" not in captured.out
+    assert "asserted by" not in captured.out
+
+
+def test_gmm_skips_fast_path_for_cue_weighting(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Even with linear moment, CUE weighting skips the fast path."""
+
+    data = _make_panel()
+    dgp = dp.EmpiricalDGP(observation=data, seed=0)
+    M = Manifold.from_pymanopt(Euclidean(1))
+    # Default weighting is CUE (None -> CUEWeighting); leave it.
+    gmm = GMM(
+        moment_func=_g_linear,
+        dgp=dgp,
+        manifold=M,
+        initial_point=jnp.zeros(1),
+        verbosity=1,
+    )
+    gmm.estimate(optimizer_kwargs={"verbosity": 0})
+    captured = capsys.readouterr()
+    # CUE skips the fast path before any detection runs.
+    assert "linear moment" not in captured.out
+    assert "asserted by" not in captured.out
+
+
+def test_gmm_closed_form_recovers_correct_point_estimate() -> None:
+    """End-to-end: closed-form warm start lands at the analog (empirical mean)."""
+
+    data = _make_panel()
+    dgp = dp.EmpiricalDGP(observation=data, seed=0)
+    M = Manifold.from_pymanopt(Euclidean(1))
+    gmm = GMM(
+        moment_func=_g_linear,
+        dgp=dgp,
+        manifold=M,
+        initial_point=jnp.zeros(1),
+        weighting=IdentityWeighting(1),
+    )
+    result = gmm.estimate(optimizer_kwargs={"verbosity": 0})
+    np.testing.assert_allclose(
+        float(np.asarray(result.theta_array)[0]),
+        float(data.mean()),
+        atol=1e-6,
+    )
+
+
+# --------------------------------------------------------------------------
+# Bump function: pathological case (jaxpr correctly catches the exp)
+# --------------------------------------------------------------------------
+def test_jaxpr_walker_rejects_bump_function() -> None:
+    """The classic bump function evaluated at ``x <= 0`` has Hessian zero
+    on (-inf, 0) but isn't affine globally; the jaxpr walker sees the
+    ``exp`` in the true branch of the ``cond`` and rejects.
+    """
+
+    import jax
+
+    def g_bump(theta, data):
+        # g(theta, data) = data - bump(theta_scalar)
+        # bump(t) = exp(-1/t) for t > 0, else 0.
+        def true_branch(t):
+            return jnp.exp(-1.0 / t)
+
+        def false_branch(t):
+            return jnp.zeros_like(t)
+
+        t = theta[0]
+        bump = jax.lax.cond(t > 0, true_branch, false_branch, t)
+        return data - bump
+
+    data = jnp.asarray(np.array([1.0, 2.0, 3.0]))
+    # Trace at theta = -1 (false branch).  Numerical Hessian would
+    # falsely conclude "affine"; the jaxpr walker should still see
+    # the ``exp`` in the true branch and reject.
+    assert is_affine_in_theta(g_bump, jnp.array([-1.0]), data) is False

--- a/tests/v2/test_linearity.py
+++ b/tests/v2/test_linearity.py
@@ -267,10 +267,18 @@ def test_gmm_skips_fast_path_for_nonlinear_moment(
     assert "asserted by" not in captured.out
 
 
-def test_gmm_skips_fast_path_for_cue_weighting(
+def test_gmm_skips_per_stage_closed_form_for_cue_weighting(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """Even with linear moment, CUE weighting skips the fast path."""
+    """CUE weighting on a 1-step estimate doesn't use per-stage closed form.
+
+    Linearity *is* still detected (the moment doesn't change just
+    because the weighting is CUE) and the v=1 message fires.  But
+    the *per-stage* closed-form solve doesn't fire for the (sole)
+    CUE-weighted stage; verbosity=2 would normally print
+    ``GMM stage closed-form: ...`` per closed-form stage, and we
+    verify that line is absent here.
+    """
 
     data = _make_panel()
     dgp = dp.EmpiricalDGP(observation=data, seed=0)
@@ -281,13 +289,57 @@ def test_gmm_skips_fast_path_for_cue_weighting(
         dgp=dgp,
         manifold=M,
         initial_point=jnp.zeros(1),
-        verbosity=1,
+        verbosity=2,
     )
     gmm.estimate(optimizer_kwargs={"verbosity": 0})
     captured = capsys.readouterr()
-    # CUE skips the fast path before any detection runs.
-    assert "linear moment" not in captured.out
-    assert "asserted by" not in captured.out
+    # Detection still fires (CUE is orthogonal to whether the
+    # moment is affine in theta).
+    assert "linear moment in theta detected" in captured.out
+    # ... but the per-stage closed-form solve does not, because the
+    # 1-step CUE-weighted stage is theta-dependent.
+    assert "stage closed-form" not in captured.out
+
+
+def test_gmm_two_step_with_cue_kwarg_uses_per_stage_closed_form(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``two_step=True`` overrides stage 1 to identity and computes Omega^-1
+    for stage 2; both stages are then theta-independent and trigger the
+    closed-form per-stage path, regardless of the user-supplied
+    ``weighting`` (CUE here).  This is the 3SLS-equivalent fast path.
+    """
+
+    # Over-identified linear moment: y = data with 2 columns, theta
+    # is a scalar.  Use g(theta, X) = X - theta (broadcast to (N, 2)).
+    rng = np.random.default_rng(0)
+    data = jnp.asarray(rng.standard_normal(size=(40, 2)) + 1.5)
+
+    def g_overid(theta, x):
+        return x - theta  # shape (N, 2); k=2 moments, p=1 param
+
+    dgp = dp.EmpiricalDGP(observation=data, seed=0)
+    M = Manifold.from_pymanopt(Euclidean(1))
+    gmm = GMM(
+        moment_func=g_overid,
+        dgp=dgp,
+        manifold=M,
+        initial_point=jnp.zeros(1),
+        verbosity=2,
+    )
+    result = gmm.estimate(two_step=True, optimizer_kwargs={"verbosity": 0})
+    captured = capsys.readouterr()
+    # Linearity detected ...
+    assert "linear moment in theta detected" in captured.out
+    # ... and *both* stages solve in closed form (two messages).
+    assert captured.out.count("stage closed-form") == 2
+
+    # And the estimate is sensible.  The over-identified analog
+    # under identity weighting is the average over both columns; the
+    # efficient (Omega^-1) weighting tightens this further but still
+    # near the mean of the data.
+    theta_hat = float(np.asarray(result.theta_array)[0])
+    assert abs(theta_hat - float(data.mean())) < 0.2
 
 
 def test_gmm_closed_form_recovers_correct_point_estimate() -> None:

--- a/tests/v2/test_two_way_fe_v2.py
+++ b/tests/v2/test_two_way_fe_v2.py
@@ -1,0 +1,91 @@
+"""Smoke test for :file:`tests/v2/two_way_fe_v2.py`.
+
+Verifies that the two-way fixed-effects panel example runs end-to-end
+and produces statistically sensible output:
+
+- Point estimate ``beta_hat`` lies in a neighbourhood of the truth
+  ``(2, -1)`` (loose band; N = 30 with two FE dimensions absorbed
+  leaves limited residual signal).
+- Just-identified criterion at the optimum is numerically zero.
+- Parametric bootstrap mean concentrates near the truth.
+- Empirical (cluster-by-unit) bootstrap mean concentrates near the
+  point estimate.
+- Both bootstrap SEs are non-trivial and roughly agree, demonstrating
+  that the sampling-design switch from ``ParametricDGP`` to
+  ``EmpiricalDGP`` propagates correctly through the v2 GMM machinery
+  without any estimator-side changes.
+
+Behavioral test (tolerance bands sized for MC variation at the
+example's panel dimensions), not a pinned-output test.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+# Make the sibling ``two_way_fe_v2`` module importable.
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+two_way_fe_v2 = pytest.importorskip(
+    "two_way_fe_v2",
+    reason="tests/v2/two_way_fe_v2.py requires dgp_protocol + jax + pymanopt",
+)
+
+
+def test_two_way_fe_end_to_end_run(capsys: pytest.CaptureFixture[str]) -> None:
+    """End-to-end smoke: estimate, parametric bootstrap, empirical bootstrap."""
+
+    stats = two_way_fe_v2.run()
+    captured = capsys.readouterr()
+    assert "FWL-GMM point estimate" in captured.out
+    assert "parametric bootstrap" in captured.out
+    assert "empirical cluster-by-unit bootstrap" in captured.out
+
+    beta_hat = np.asarray(stats["beta_hat"], dtype=float)
+    beta_true = two_way_fe_v2.BETA_TRUE
+    # Point estimate within ~0.1 of truth (N=30, T=6, two FE
+    # dimensions absorbed; ~150 effective observations).
+    assert np.all(
+        np.abs(beta_hat - beta_true) < 0.15
+    ), f"beta_hat = {beta_hat} too far from truth {beta_true}"
+
+    # Just-identified: criterion at optimum is essentially zero.
+    assert stats["criterion_value"] < 1e-10
+
+    # Parametric bootstrap: mean concentrates near the truth (this
+    # is the sampling distribution under the *true* DGP).
+    pm = np.asarray(stats["bootstrap_parametric_mean"], dtype=float)
+    pse = np.asarray(stats["bootstrap_parametric_se"], dtype=float)
+    assert np.all(
+        np.abs(pm - beta_true) < 0.05
+    ), f"parametric bootstrap mean {pm} too far from truth {beta_true}"
+    # SEs are non-trivial and modest (we expect O(0.03-0.1) at N=30).
+    assert np.all(0.005 < pse) and np.all(
+        pse < 0.2
+    ), f"parametric bootstrap SE {pse} outside reasonable band"
+
+    # Empirical bootstrap: mean concentrates near the point estimate.
+    em = np.asarray(stats["bootstrap_empirical_mean"], dtype=float)
+    ese = np.asarray(stats["bootstrap_empirical_se"], dtype=float)
+    assert np.all(
+        np.abs(em - beta_hat) < 0.1
+    ), f"empirical bootstrap mean {em} too far from point estimate {beta_hat}"
+    assert np.all(0.005 < ese) and np.all(
+        ese < 0.2
+    ), f"empirical bootstrap SE {ese} outside reasonable band"
+
+    # The two bootstrap SEs should be roughly the same order of
+    # magnitude (one is the sampling distribution under the true
+    # DGP; the other is the cluster-by-unit resample of the
+    # observed realization).  Allow a 4x ratio either way.
+    ratio = pse / ese
+    assert np.all((0.25 < ratio) & (ratio < 4.0)), (
+        f"parametric vs empirical SE ratio {ratio} suggests the two "
+        f"bootstrap paths disagree implausibly -- v2 plumbing bug?"
+    )

--- a/tests/v2/two_way_fe_v2.py
+++ b/tests/v2/two_way_fe_v2.py
@@ -1,0 +1,355 @@
+"""Two-way fixed-effects panel regression, v2 GMM via FWL projection.
+
+End-to-end demonstration of three v2 design ideas at once:
+
+1. *Panel data fits the (rows = units) convention without extension.*
+   Each row of the data array is one unit's full T-vector (or T x p
+   block); the GMM framework's iid resampling over rows IS the
+   cluster-by-unit bootstrap.  No estimator-side cluster logic needed.
+
+2. *Nuisance parameters (the FE intercepts) are concentrated out via
+   Frisch-Waugh-Lovell inside the moment function.*  The optimizer
+   sees only ``beta``; the parameter manifold is ``Euclidean(p)``.
+
+3. *The sampling design is an aspect of the DGP, not the estimator.*
+   The same ``GMM(moment_func, dgp, ...)`` works whether ``dgp`` is
+   a parametric panel simulator (power study) or an
+   ``EmpiricalDGP`` over an observed panel (raw-data cluster
+   bootstrap); the GMM doesn't know or care.
+
+Model
+-----
+For unit ``i = 1..N`` and time ``t = 1..T``::
+
+    y_{i,t} = alpha_i + gamma_t + x_{i,t}' beta + eps_{i,t}
+
+with alpha_i ~ N(0, sigma_alpha^2), gamma_t ~ N(0, sigma_gamma^2),
+eps ~ N(0, sigma^2) all independent.  Panels can be unbalanced;
+missing cells are marked with ``NaN`` in the wide-format data
+array.  Truth here: ``beta = (2, -1)``, ``sigma_alpha = sigma_gamma
+= 0.5``, ``sigma = 0.3``.
+
+Moment condition
+----------------
+After Frisch-Waugh-Lovell projection of ``y`` and ``x`` onto the
+orthogonal complement of the (unit dummies, time dummies, constant)
+nuisance regressors,
+
+    E[ x_tilde_{i,t} (y_tilde_{i,t} - x_tilde_{i,t}' beta) ] = 0,
+
+with the per-unit aggregation summing over the observed time
+periods within unit ``i``::
+
+    g_i(beta, X_i) = sum_{t : observed} x_tilde_{i,t}
+                     * (y_tilde_{i,t} - x_tilde_{i,t}' beta).
+
+The framework's ``(N, k)``-shaped vectorized moment makes this the
+natural unit-of-clustering: each row of ``g(beta, data)`` is one
+unit's contribution, summed over time.
+
+FWL for unbalanced panels
+-------------------------
+The within transformation ``z - z_bar_i - z_bar_t + z_bar`` only
+gives the exact FE projection on *balanced* panels.  For unbalanced
+panels we apply the general FWL projector ``M_D = I - D (D'D)^-1
+D'`` where ``D`` is the (N + T - 1)-column dummy matrix (unit
+dummies + time dummies minus one for the absorbed constant), masked
+to the observed cells.  The masked least-squares problem is solved
+via :func:`jax.numpy.linalg.lstsq`, giving the exact within
+estimator on any observation pattern.  This mirrors the spirit of
+the ``fwl_regression`` helper in :file:`MetricsMiscellany`: the
+projection is the right primitive, and it works without a balanced-
+panel assumption.
+
+Run directly::
+
+    python tests/v2/two_way_fe_v2.py
+"""
+
+from __future__ import annotations
+
+import sys
+import warnings
+from pathlib import Path
+
+import dgp_protocol as dp
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+# Same pymanopt RuntimeWarning as in the other v2 examples: harmless
+# trust-region degenerate-step under our scaling.
+warnings.filterwarnings(
+    "ignore",
+    category=RuntimeWarning,
+    message="invalid value encountered in scalar divide",
+)
+
+# Ensure ManifoldGMM is importable when run as a script from any cwd.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+from manifoldgmm import GMM, Manifold  # noqa: E402
+from manifoldgmm.econometrics.gmm import IdentityWeighting  # noqa: E402
+from pymanopt.manifolds import Euclidean  # noqa: E402
+
+# --------------------------------------------------------------------------
+# Parametric DGP
+# --------------------------------------------------------------------------
+# Panel dimensions and truth.
+N: int = 30
+T: int = 6
+P: int = 2  # number of x regressors
+BETA_TRUE: np.ndarray = np.array([2.0, -1.0])
+SIGMA_ALPHA: float = 0.5
+SIGMA_GAMMA: float = 0.5
+SIGMA_EPS: float = 0.3
+# Probability that any given (i, t) cell is observed (1 - missingness).
+KEEP_PROB: float = 0.85
+# Independent seed for the observation mask -- distinct from the
+# DGP's own draw seed so the missingness pattern is fixed.
+MASK_SEED: int = 2026
+
+
+def _draw_mask(rng: np.random.Generator) -> np.ndarray:
+    """Draw an (N, T) Bernoulli observation mask, ensuring no fully-missing
+    unit or time period (which would make the FE dummy matrix rank-deficient).
+    """
+
+    while True:
+        mask = rng.binomial(1, KEEP_PROB, size=(N, T)).astype(bool)
+        if mask.any(axis=1).all() and mask.any(axis=0).all():
+            return mask
+
+
+# Fix the observation pattern once at module load time; it serves both
+# as a structural feature of the parametric DGP (which always returns
+# data with this same NaN pattern) and as the mask for the bound
+# observation.
+_OBS_MASK: np.ndarray = _draw_mask(np.random.default_rng(MASK_SEED))
+
+
+def two_way_fe_generator(
+    rng: np.random.Generator, shape: tuple[int, ...]
+) -> np.ndarray:
+    """Generate one (N, T, 1+P) panel realization from the two-way FE model.
+
+    Ignores ``shape`` (the panel dimensions are fixed by module
+    constants ``N``, ``T``, ``P``).  Returns a numpy array with
+    ``NaN`` where the fixed mask ``_OBS_MASK`` says the cell is
+    missing.
+    """
+
+    del shape  # the generator is dimensioned by module constants
+    alpha = rng.normal(0.0, SIGMA_ALPHA, size=N)
+    gamma = rng.normal(0.0, SIGMA_GAMMA, size=T)
+    x = rng.normal(0.0, 1.0, size=(N, T, P))
+    eps = rng.normal(0.0, SIGMA_EPS, size=(N, T))
+    y = alpha[:, None] + gamma[None, :] + (x @ BETA_TRUE) + eps
+    # Mark missing cells as NaN in both y and x.
+    y_masked = np.where(_OBS_MASK, y, np.nan)
+    x_masked = np.where(_OBS_MASK[..., None], x, np.nan)
+    return np.concatenate([y_masked[..., None], x_masked], axis=-1)
+
+
+# Bound observation: one draw with a seed distinct from the DGP's
+# own draw seed (mirrors the ``OBS_SEED`` convention used in the
+# fair_coin and coin_plus_noise upstream examples).
+OBS_DRAW_SEED: int = 2027
+_OBSERVATION: np.ndarray = two_way_fe_generator(
+    np.random.default_rng(OBS_DRAW_SEED), shape=()
+)
+
+# The DGP itself: a ParametricDGP that simulates fresh panels from
+# the same two-way FE model.  Each ``draw`` produces an (N, T, 1+P)
+# array with the same NaN pattern as ``_OBSERVATION``.
+panel_dgp = dp.ParametricDGP(
+    generator=two_way_fe_generator,
+    default_shape=(N, T, 1 + P),
+    observation=_OBSERVATION,
+    seed=0,
+)
+
+
+# --------------------------------------------------------------------------
+# FWL projection (precomputed nuisance design)
+# --------------------------------------------------------------------------
+# Construct the long-form (NT, N + T - 1) dummy design matrix once.
+# The mask is *not* precomputed because under the empirical
+# cluster-by-unit bootstrap each replication's mask depends on which
+# units were resampled (rows are shuffled wholesale).  Each
+# moment-function call therefore recovers the mask from the data's
+# NaN pattern and applies a fresh FWL projection via lstsq.
+_idx_unit_long = jnp.repeat(jnp.arange(N), T)  # (NT,)
+_idx_time_long = jnp.tile(jnp.arange(T), N)  # (NT,)
+_D_unit = jax.nn.one_hot(_idx_unit_long, N)  # (NT, N)
+_D_time = jax.nn.one_hot(_idx_time_long, T)  # (NT, T)
+# Drop one time dummy so the unit dummies span the absorbed constant.
+_D = jnp.concatenate([_D_unit, _D_time[:, 1:]], axis=1)  # (NT, N + T - 1)
+
+
+# --------------------------------------------------------------------------
+# Moment function: FWL-projected, per-unit aggregated
+# --------------------------------------------------------------------------
+def g(beta: jnp.ndarray, data: jnp.ndarray) -> jnp.ndarray:
+    """Two-way FE GMM moment, per-unit aggregated, NaN-aware.
+
+    Parameters
+    ----------
+    beta:
+        Length-``P`` parameter vector.
+    data:
+        Wide-format panel of shape ``(N, T, 1 + P)``.  Slice
+        ``data[..., 0]`` is ``y``; ``data[..., 1:]`` is ``x``.
+        ``NaN`` marks missing cells.
+
+    Returns
+    -------
+    Shape ``(N, P)`` per-unit moment vectors, one row per unit,
+    summed over the unit's observed time periods.
+
+    Notes
+    -----
+    The FWL projection is recomputed each call so this function is
+    correct under any bootstrap that may permute the per-row NaN
+    patterns (empirical cluster-by-unit in particular).  Cost per
+    call is dominated by two SVD-based ``lstsq`` solves of
+    ``(NT, N + T - 1)`` size.
+    """
+
+    y = data[..., 0]  # (N, T)
+    x = data[..., 1:]  # (N, T, P)
+    mask = (~jnp.isnan(y)).astype(jnp.float64)  # (N, T): 1 where observed
+
+    # Replace NaN with 0 so the multiplications absorb missing cells
+    # without propagating NaN.
+    y0 = jnp.nan_to_num(y).reshape(-1)  # (NT,)
+    x0 = jnp.nan_to_num(x).reshape(-1, P)  # (NT, P)
+    mask_long = mask.reshape(-1)  # (NT,)
+
+    # Apply mask to the design so missing observations contribute 0
+    # to the least-squares projection.
+    D_m = _D * mask_long[:, None]  # (NT, N + T - 1)
+    y_m = y0 * mask_long  # (NT,)
+    x_m = x0 * mask_long[:, None]  # (NT, P)
+
+    # FWL projection via SVD-based least squares.  ``lstsq`` handles
+    # any rank deficiency from masked rows or empty time/unit
+    # categories in the resample.
+    coef_y, *_ = jnp.linalg.lstsq(D_m, y_m, rcond=None)
+    coef_x, *_ = jnp.linalg.lstsq(D_m, x_m, rcond=None)
+    y_tilde = y_m - D_m @ coef_y  # (NT,)
+    x_tilde = x_m - D_m @ coef_x  # (NT, P)
+
+    # Per-observation moment: x_tilde * eps_tilde, masked.
+    eps_tilde = (y_tilde - x_tilde @ beta) * mask_long  # (NT,)
+    m_obs = x_tilde * eps_tilde[:, None]  # (NT, P)
+
+    # Aggregate to per-unit (sum over T inside each unit).  The
+    # resulting (N, P) array's row i is one unit's full moment
+    # contribution -- the natural cluster-of-clustering unit.
+    return m_obs.reshape(N, T, P).sum(axis=1)
+
+
+# --------------------------------------------------------------------------
+# End-to-end run
+# --------------------------------------------------------------------------
+def run() -> dict[str, float | np.ndarray]:
+    """Run the example end-to-end and return summary statistics."""
+
+    print(
+        f"panel: N={N} units, T={T} periods, {int(_OBS_MASK.sum())} "
+        f"of {N * T} cells observed ({100 * _OBS_MASK.mean():.1f}% balanced)"
+    )
+    print(
+        f"truth: beta={BETA_TRUE},  sigma_alpha={SIGMA_ALPHA},  "
+        f"sigma_gamma={SIGMA_GAMMA},  sigma={SIGMA_EPS}"
+    )
+    print()
+
+    M = Manifold.from_pymanopt(Euclidean(P))
+    # IdentityWeighting: just-identified problem (k == p == P), so any
+    # positive-definite weighting yields the same point estimate; the
+    # default CUEWeighting introduces non-convexity into the criterion
+    # surface unnecessarily and can derail the optimizer on noisy
+    # bootstrap replications.
+    gmm = GMM(
+        moment_func=g,
+        dgp=panel_dgp,
+        manifold=M,
+        initial_point=jnp.zeros(P),
+        weighting=IdentityWeighting(P),
+    )
+
+    # Point estimate.  Just-identified (k = P = 2 moments, p = 2
+    # parameters) so two-step and one-step are equivalent and the
+    # criterion at the optimum is essentially zero.
+    quiet = {"verbosity": 0}
+    result = gmm.estimate(optimizer_kwargs=quiet)
+    beta_hat = np.asarray(result.theta_array, dtype=float)
+    print("FWL-GMM point estimate:")
+    print(f"  beta_hat = {beta_hat}     (true {BETA_TRUE})")
+    print(f"  criterion at optimum = {result.criterion_value:.4e}")
+    print()
+
+    # Parametric bootstrap: each replication draws a fresh panel from
+    # the true two-way FE generator (new alpha_i, gamma_t, eps_{i,t},
+    # and x_{i,t}, but the same missing-cell pattern) and refits.
+    # This is the *parametric* bootstrap of the sampling distribution
+    # of beta_hat under the true DGP.
+    B = 25
+    print(f"parametric bootstrap (fresh panels from the DGP): B={B}, seed=42 ...")
+    bs = gmm.bootstrap(B=B, seed=42, optimizer_kwargs=quiet)
+    bs_betas = np.stack([np.asarray(t.value, dtype=float) for t in bs.thetas])
+    print(f"  bootstrap mean = {bs_betas.mean(axis=0)}")
+    print(f"  bootstrap SE   = {bs_betas.std(axis=0, ddof=1)}")
+    print()
+
+    # And now the *empirical* bootstrap: take the observed
+    # realization, build an EmpiricalDGP whose default ``IIDSampling``
+    # resamples rows -- which IS the cluster-by-unit bootstrap, since
+    # each row of the wide-format panel is one unit's full T-vector.
+    # The GMM, moment function, and bootstrap machinery are
+    # bit-identical to the parametric case; only the DGP changes.
+    print(
+        "empirical cluster-by-unit bootstrap "
+        "(EmpiricalDGP over the observed panel): same B and seed ..."
+    )
+    emp_dgp = dp.EmpiricalDGP(observation=panel_dgp.data, seed=0)
+    emp_gmm = GMM(
+        moment_func=g,
+        dgp=emp_dgp,
+        manifold=M,
+        initial_point=jnp.zeros(P),
+        weighting=IdentityWeighting(P),
+    )
+    emp_result = emp_gmm.estimate(optimizer_kwargs=quiet)
+    emp_beta_hat = np.asarray(emp_result.theta_array, dtype=float)
+    # Point estimate is identical (same data, same moment function)
+    # up to optimizer tolerance:
+    assert np.allclose(beta_hat, emp_beta_hat, atol=1e-6)
+    emp_bs = emp_gmm.bootstrap(B=B, seed=42, optimizer_kwargs=quiet)
+    emp_bs_betas = np.stack([np.asarray(t.value, dtype=float) for t in emp_bs.thetas])
+    print(f"  bootstrap mean = {emp_bs_betas.mean(axis=0)}")
+    print(f"  bootstrap SE   = {emp_bs_betas.std(axis=0, ddof=1)}")
+    print()
+
+    print(
+        "(parametric bootstrap is the sampling distribution under "
+        "the *true* DGP; empirical bootstrap is the cluster-by-unit "
+        "resample of the observed panel.  Both flow through the same "
+        "GMM machinery -- the sampling design lives entirely in the DGP.)"
+    )
+
+    return {
+        "beta_hat": beta_hat,
+        "criterion_value": float(result.criterion_value),
+        "bootstrap_parametric_mean": bs_betas.mean(axis=0),
+        "bootstrap_parametric_se": bs_betas.std(axis=0, ddof=1),
+        "bootstrap_empirical_mean": emp_bs_betas.mean(axis=0),
+        "bootstrap_empirical_se": emp_bs_betas.std(axis=0, ddof=1),
+    }
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
## Summary

- `manifoldgmm.NumericalWarning` now multi-inherits from `dgp_protocol.NumericalWarning` and `UserWarning`, so a user's `filterwarnings(category=...)` on either package's `NumericalWarning` catches instances of both.

## Why

DGP_Protocol (a runtime dep on the `v2-dgp` branch) defines its own `NumericalWarning` — a *different* class with the same name, raised from adaptive-MC budget exhaustion in the new distributional-features path (`dgp.sample_distribution.expect/.cov/.moment_covariance`).

Today:

| filter | catches `manifoldgmm.NumericalWarning` | catches `dgp_protocol.NumericalWarning` |
|---|---|---|
| `manifoldgmm.NumericalWarning` | ✅ | ❌ |
| `dgp_protocol.NumericalWarning` | ❌ | ✅ |
| `UserWarning` | ✅ (subclass) | ❌ |
| `RuntimeWarning` | ❌ | ✅ (subclass) |

A user who installs one filter to "make numerical-quality warnings into errors" only covers one flavour and silently misses the other. Confusing UX given the identical names.

After this change:

| filter | catches `manifoldgmm.NumericalWarning` | catches `dgp_protocol.NumericalWarning` |
|---|---|---|
| `manifoldgmm.NumericalWarning` | ✅ | ❌ |
| **`dgp_protocol.NumericalWarning`** | **✅** (new) | ✅ |
| `UserWarning` | ✅ (preserved) | ❌ |
| `RuntimeWarning` | **✅** (new) | ✅ |

DGP_Protocol is the lower-level package, so making it the "primary" base for the numerical-quality category lets a single `filterwarnings(category=dgp_protocol.NumericalWarning)` cover both layers. Existing filters that broaden over `UserWarning` keep working because we retain `UserWarning` as a co-base.

## MRO

`manifoldgmm.NumericalWarning` → `dgp_protocol.NumericalWarning` → `RuntimeWarning` → `UserWarning` → `Warning` → `Exception` → `BaseException` → `object`

Verified: `issubclass(...)` is True for `dgp_protocol.NumericalWarning`, `UserWarning`, and `RuntimeWarning`.

## Test plan

- [x] `pytest tests/utils/test_ridge_inverse.py tests/econometrics/test_diagnostics_namespace.py tests/econometrics/test_compute_hessian_cond_gauge.py tests/test_logging_trust_regions.py` — 55 NumericalWarning-touching tests still pass.
- [x] `ruff check src/manifoldgmm/_warnings.py` — clean.
- [x] `black --check src/manifoldgmm/_warnings.py` — clean.
- [x] `mypy src tests` — 61 source files, no issues.
- [ ] CI on `feature/**` push will exercise the full suite.

## Caveat

Downstream code that does `warnings.filterwarnings("ignore", category=UserWarning)` is *unchanged* (still catches our `NumericalWarning`). Downstream code that relies on `issubclass(manifoldgmm.NumericalWarning, RuntimeWarning) == False` would break, but that's a strange thing to rely on and the new relationship is conceptually correct (a "degraded numerical regime" is a runtime-quality concern as much as a user one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)