### PR TITLE
Deprecate MomentRestriction.with_clusters / with_weights (closes #47)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,13 @@ Run before every handoff: `make check` (ruff, black, mypy, pytest). Or `make qui
 ## Error Types
 Use canonical exceptions: `ManifoldError`, `RetractionError`, `ProjectionError`, `JacobianShapeError`, `WeightingError`, `NumericalWarning`, `GaugeWarning`, `ConvergenceWarning`.
 
+## Three-Layer Responsibility Map (v0.4+)
+- **Model** (`MomentRestriction`): moment function (`g` / `gi_jax`) + parameter manifold + autodiff backend.  No sampling-design state.
+- **Data** (`dgp_protocol.DataGeneratingProcess`): the observed realization + a way to draw fresh realizations + the sampling design (iid / cluster / two-stage).  Cluster ids and per-observation weights live here.
+- **Bridge** (`GMM` + `GMMResult`): weighting, optimizer, penalty, inference machinery; connects (model, DGP) to a fitted point.
+
+`MomentRestriction.with_clusters` / `with_weights` are deprecated (issue #47): construct `EmpiricalDGP(sampling=ClusteredSampling(cluster_ids=...))` or `EmpiricalDGP(sampling=IIDSampling(weights=...))` plus `GMM(moment_func=g, dgp=dgp, ...)` instead.  Removal scheduled for v0.5.
+
 ## Org-Mode Conventions
 - ASCII-safe LaTeX only (no Unicode math characters).
 - Display math: `\[ \]` or `\begin{equation}`.
@@ -24,7 +31,7 @@ Use canonical exceptions: `ManifoldError`, `RetractionError`, `ProjectionError`,
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **ManifoldGMM** (1804 symbols, 3261 relationships, 155 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **ManifoldGMM** (2162 symbols, 3363 relationships, 96 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/docs/release/notes_0.4.0a1.org
+++ b/docs/release/notes_0.4.0a1.org
@@ -82,6 +82,25 @@ no source changes required.
   need updating; the positive direction (=issubclass(NumericalWarning,
   UserWarning) == True=) is preserved.
 
+- *=MomentRestriction.with_clusters= / =with_weights= deprecated* (issue #47).
+  Sampling-design state (cluster ids, per-observation weights) now belongs
+  on the DGP's :class:`~dgp_protocol.SamplingDesign`.  Both methods continue
+  to work but emit =DeprecationWarning= pointing users at the v2 equivalent:
+  ::
+
+    # v1 (deprecated):
+    r = MomentRestriction(g=g, data=X).with_clusters(ids)
+    gmm = GMM(r, ...)
+
+    # v2:
+    dgp = EmpiricalDGP(observation=X, sampling=ClusteredSampling(cluster_ids=ids))
+    gmm = GMM(moment_func=g, dgp=dgp, ...)
+
+  Library-internal callers (notably the moment-error bootstrap in
+  =econometrics/bootstrap.py=) use the no-warn private aliases
+  =_set_clusters= / =_set_weights= and are unaffected.  Scheduled for
+  removal in v0.5.
+
 * Backward compatibility for v1 callers
 - =GMM(restriction, ...)= -- unchanged.  The v1 constructor signature is
   preserved bit-identically; v1 keyword/positional invocations both still work.

--- a/src/manifoldgmm/econometrics/bootstrap.py
+++ b/src/manifoldgmm/econometrics/bootstrap.py
@@ -349,9 +349,13 @@ class BootstrapTask:
             cluster_weights = generator(self.num_clusters, rng)
             weights = np.asarray(cluster_weights)[codes]
 
-        weighted_restriction = self.restriction.with_weights(weights)
+        # Use the no-warn internal mutators -- the v1 moment-error
+        # bootstrap path is the legitimate library-internal consumer of
+        # weight-and-cluster cloning.  Public ``with_weights`` /
+        # ``with_clusters`` emit DeprecationWarning per issue #47.
+        weighted_restriction = self.restriction._set_weights(weights)
         if self.restriction.clusters is not None:
-            weighted_restriction = weighted_restriction.with_clusters(
+            weighted_restriction = weighted_restriction._set_clusters(
                 self.restriction.clusters
             )
 
@@ -771,10 +775,12 @@ class MomentWildBootstrap:
         # Attach the resolved cluster ids to the task-side restriction if
         # the bootstrap is operating in clustered mode and the original
         # restriction did not already carry the same assignment.  This
-        # ensures `BootstrapTask.run`'s `with_clusters` chaining produces a
-        # cluster-robust replicate Omega for every replicate.
+        # ensures `BootstrapTask.run`'s ``_set_clusters`` chaining produces
+        # a cluster-robust replicate Omega for every replicate.  Uses the
+        # no-warn private mutator since this is library-internal v1
+        # plumbing (see issue #47 for the public deprecation).
         if self._cluster_ids is not None and restriction.clusters is None:
-            restriction = restriction.with_clusters(self._cluster_ids)
+            restriction = restriction._set_clusters(self._cluster_ids)
 
         theta_hat = self._gmm_result.theta_point
         # Use the ambient value as initial point for each replicate

--- a/src/manifoldgmm/econometrics/moment_restriction.py
+++ b/src/manifoldgmm/econometrics/moment_restriction.py
@@ -214,8 +214,35 @@ class MomentRestriction:
 
         return self._weights
 
+    def _set_weights(self, weights: Any) -> MomentRestriction:
+        """Internal counterpart to :meth:`with_weights` that does not warn.
+
+        Used by library-internal call sites (notably
+        :mod:`manifoldgmm.econometrics.bootstrap`) where the v1
+        weighted-clone idiom remains the active code path.  Public
+        callers should construct the v2 DGP-side equivalent;
+        :meth:`with_weights` exposes that recommendation as a
+        :class:`DeprecationWarning`.
+        """
+
+        import copy
+
+        clone = copy.copy(self)
+        clone._weights = weights
+        return clone
+
     def with_weights(self, weights: Any) -> MomentRestriction:
         """Return a shallow copy carrying the supplied bootstrap weights.
+
+        .. deprecated:: 0.4
+            Sampling-design state (weights, cluster ids) now lives on
+            the DGP's :class:`~dgp_protocol.SamplingDesign`.  Use
+            ``EmpiricalDGP(observation=X, sampling=IIDSampling(weights=...))``
+            (or ``ClusteredSampling(cluster_ids=..., weights=...)``) with
+            ``GMM(moment_func=g, dgp=dgp, ...)``.  This method emits a
+            :class:`DeprecationWarning` for one minor release and will
+            be removed in v0.5.  See ``docs/design/v2_dgp.org`` and
+            ManifoldGMM issue #47.
 
         The returned instance shares the dataset, manifold, moment map, and
         all cached metadata with the original --- only the weights differ.
@@ -229,11 +256,21 @@ class MomentRestriction:
             broadcast against ``(n,)``.
         """
 
-        import copy
+        import warnings
 
-        clone = copy.copy(self)
-        clone._weights = weights
-        return clone
+        warnings.warn(
+            "MomentRestriction.with_weights is deprecated and will be "
+            "removed in v0.5.  Sampling-design state (weights, cluster "
+            "ids) now belongs to the DGP's SamplingDesign.  Construct the "
+            "v2 equivalent: EmpiricalDGP(observation=X, "
+            "sampling=IIDSampling(weights=...)) (or "
+            "ClusteredSampling(cluster_ids=..., weights=...)) with "
+            "GMM(moment_func=g, dgp=dgp, ...).  See "
+            "docs/design/v2_dgp.org and issue #47.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._set_weights(weights)
 
     @property
     def clusters(self) -> Any | None:
@@ -248,8 +285,38 @@ class MomentRestriction:
 
         return self._clusters
 
+    def _set_clusters(self, cluster_ids: Any) -> MomentRestriction:
+        """Internal counterpart to :meth:`with_clusters` that does not warn.
+
+        Used by library-internal call sites where the v1 clustered-
+        clone idiom remains the active code path (see
+        :meth:`_set_weights` for the same pattern on the weights side).
+        Public callers should construct the v2 DGP-side equivalent;
+        :meth:`with_clusters` exposes that recommendation as a
+        :class:`DeprecationWarning`.
+        """
+
+        import copy
+
+        clone = copy.copy(self)
+        clone._clusters = cluster_ids
+        # Drop any cached integer codes inherited from ``self`` so the clone
+        # recomputes them lazily against the new assignment.
+        clone._cluster_codes = None
+        clone._num_clusters = None
+        return clone
+
     def with_clusters(self, cluster_ids: Any) -> MomentRestriction:
         """Return a shallow copy carrying the supplied cluster identifiers.
+
+        .. deprecated:: 0.4
+            Cluster identifiers now live on the DGP's
+            :class:`~dgp_protocol.SamplingDesign`.  Use
+            ``EmpiricalDGP(observation=X, sampling=ClusteredSampling(cluster_ids=ids))``
+            with ``GMM(moment_func=g, dgp=dgp, ...)`` instead.  This
+            method emits a :class:`DeprecationWarning` for one minor
+            release and will be removed in v0.5.  See
+            ``docs/design/v2_dgp.org`` and ManifoldGMM issue #47.
 
         Mirrors :meth:`with_weights`: the returned instance shares the
         dataset, manifold, moment map, weights, and cached metadata with the
@@ -264,15 +331,20 @@ class MomentRestriction:
             internally normalised to integer codes.
         """
 
-        import copy
+        import warnings
 
-        clone = copy.copy(self)
-        clone._clusters = cluster_ids
-        # Drop any cached integer codes inherited from ``self`` so the clone
-        # recomputes them lazily against the new assignment.
-        clone._cluster_codes = None
-        clone._num_clusters = None
-        return clone
+        warnings.warn(
+            "MomentRestriction.with_clusters is deprecated and will be "
+            "removed in v0.5.  Sampling-design state (cluster ids, "
+            "weights) now belongs to the DGP's SamplingDesign.  "
+            "Construct the v2 equivalent: EmpiricalDGP(observation=X, "
+            "sampling=ClusteredSampling(cluster_ids=ids)) with "
+            "GMM(moment_func=g, dgp=dgp, ...).  See "
+            "docs/design/v2_dgp.org and issue #47.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._set_clusters(cluster_ids)
 
     @property
     def num_moments(self) -> int | None:

--- a/tests/econometrics/test_bootstrap.py
+++ b/tests/econometrics/test_bootstrap.py
@@ -425,21 +425,27 @@ class TestClusterStructural:
     def test_weights_constant_within_cluster(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """The weights handed to ``with_weights`` are cluster-constant."""
+        """The weights handed to the bootstrap weight-mutator are cluster-constant.
+
+        Spies on the private ``_set_weights`` mutator that the
+        moment-error bootstrap uses internally (issue #47 deprecated
+        the public ``with_weights`` alias; library-internal call sites
+        flow through the no-warn private path).
+        """
 
         cluster_ids = np.repeat(np.arange(3), 4)  # 12 obs / 3 clusters / size 4
         _, result, _ = _clustered_restriction_and_result(cluster_ids)
 
         from manifoldgmm.econometrics import moment_restriction as mr_mod
 
-        original_with_weights = mr_mod.MomentRestriction.with_weights
+        original_set_weights = mr_mod.MomentRestriction._set_weights
         captured_weights: list[np.ndarray] = []
 
-        def spy_with_weights(self: Any, w: Any) -> Any:
+        def spy_set_weights(self: Any, w: Any) -> Any:
             captured_weights.append(np.asarray(w).copy())
-            return original_with_weights(self, w)
+            return original_set_weights(self, w)
 
-        monkeypatch.setattr(mr_mod.MomentRestriction, "with_weights", spy_with_weights)
+        monkeypatch.setattr(mr_mod.MomentRestriction, "_set_weights", spy_set_weights)
 
         boot = MomentWildBootstrap(
             result, n_bootstrap=2, clusters=cluster_ids, base_seed=0

--- a/tests/econometrics/test_with_clusters_with_weights_deprecation.py
+++ b/tests/econometrics/test_with_clusters_with_weights_deprecation.py
@@ -1,0 +1,100 @@
+"""Issue #47: ``MomentRestriction.with_clusters`` / ``with_weights`` deprecation.
+
+Asserts that public calls to ``with_clusters`` and ``with_weights`` emit
+:class:`DeprecationWarning` pointing users at the v2 DGP-side sampling-
+design state (``EmpiricalDGP(sampling=...)``).  Library-internal callers
+use the private ``_set_clusters`` / ``_set_weights`` mutators (which do
+*not* warn) so the v1 moment-error bootstrap does not generate noise on
+its own internal cloning.
+
+Companion to the larger issue-#47 cleanup; the deprecated methods are
+scheduled for removal in v0.5.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from manifoldgmm.econometrics.moment_restriction import MomentRestriction
+
+
+def _make_restriction() -> MomentRestriction:
+    data = jnp.asarray(np.arange(12).reshape(6, 2).astype(float))
+
+    def g(theta, x):
+        return x - theta[None, :]
+
+    return MomentRestriction(g=g, data=data, backend="numpy")
+
+
+def test_with_clusters_emits_deprecation_warning() -> None:
+    """``with_clusters`` raises a ``DeprecationWarning`` pointing at v2."""
+
+    restriction = _make_restriction()
+    cluster_ids = np.array([0, 0, 0, 1, 1, 1])
+    with pytest.warns(DeprecationWarning, match="ClusteredSampling"):
+        restriction.with_clusters(cluster_ids)
+
+
+def test_with_weights_emits_deprecation_warning() -> None:
+    """``with_weights`` raises a ``DeprecationWarning`` pointing at v2."""
+
+    restriction = _make_restriction()
+    weights = np.ones(6)
+    with pytest.warns(DeprecationWarning, match="IIDSampling"):
+        restriction.with_weights(weights)
+
+
+def test_with_clusters_still_works_under_warning() -> None:
+    """The deprecated path still functions (warns + applies)."""
+
+    restriction = _make_restriction()
+    cluster_ids = np.array([0, 0, 0, 1, 1, 1])
+    with pytest.warns(DeprecationWarning):
+        clone = restriction.with_clusters(cluster_ids)
+    np.testing.assert_array_equal(np.asarray(clone.clusters), cluster_ids)
+
+
+def test_with_weights_still_works_under_warning() -> None:
+    """The deprecated path still functions (warns + applies)."""
+
+    restriction = _make_restriction()
+    weights = np.array([1.5, 0.5, 2.0, 0.0, 1.0, 1.0])
+    with pytest.warns(DeprecationWarning):
+        clone = restriction.with_weights(weights)
+    np.testing.assert_array_equal(np.asarray(clone.weights), weights)
+
+
+def test_set_clusters_internal_does_not_warn() -> None:
+    """The private ``_set_clusters`` mutator is the no-warn library internal."""
+
+    restriction = _make_restriction()
+    cluster_ids = np.array([0, 0, 0, 1, 1, 1])
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        clone = restriction._set_clusters(cluster_ids)  # would re-raise if warned
+    np.testing.assert_array_equal(np.asarray(clone.clusters), cluster_ids)
+
+
+def test_set_weights_internal_does_not_warn() -> None:
+    """The private ``_set_weights`` mutator is the no-warn library internal."""
+
+    restriction = _make_restriction()
+    weights = np.array([1.5, 0.5, 2.0, 0.0, 1.0, 1.0])
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        clone = restriction._set_weights(weights)  # would re-raise if warned
+    np.testing.assert_array_equal(np.asarray(clone.weights), weights)
+
+
+def test_warning_points_at_v2_dgp_path() -> None:
+    """The deprecation message names the v2 EmpiricalDGP construct."""
+
+    restriction = _make_restriction()
+    with pytest.warns(DeprecationWarning) as record:
+        restriction.with_clusters(np.zeros(6, dtype=int))
+    assert any("EmpiricalDGP" in str(w.message) for w in record)
+    assert any("issue #47" in str(w.message) for w in record)


### PR DESCRIPTION
## Summary

Sampling-design state (cluster ids, per-observation weights) now belongs on the DGP's `SamplingDesign` per the v2 three-layer responsibility map (Model / Data / Bridge).  `MomentRestriction` keeps the moment function + manifold + autodiff backend; cluster ids and weights migrate to:

```python
# v1 (deprecated, still works):
r = MomentRestriction(g=g, data=X).with_clusters(ids)
gmm = GMM(r, ...)

# v2:
dgp = EmpiricalDGP(observation=X, sampling=ClusteredSampling(cluster_ids=ids))
gmm = GMM(moment_func=g, dgp=dgp, ...)
```

Both deprecated methods stay functional during the warning window; scheduled for removal in v0.5.

## API change

- `MomentRestriction.with_clusters(cluster_ids)`: emits `DeprecationWarning` pointing at `EmpiricalDGP(sampling=ClusteredSampling(...))`; delegates to the new private mutator `_set_clusters`.
- `MomentRestriction.with_weights(weights)`: symmetric.  Emits `DeprecationWarning` pointing at `IIDSampling(weights=...)` / `ClusteredSampling(weights=...)`; delegates to `_set_weights`.
- Private `_set_clusters` / `_set_weights`: the no-warn workhorses.  Carry the original method bodies; safe for library-internal use.

## Library-internal callers migrated

`econometrics/bootstrap.py`: the two v1 moment-error bootstrap call sites (`BootstrapTask.run` weights + cluster chaining, and the cluster-id attachment in the task factory) switched from the deprecated public methods to the no-warn private mutators.  The v1 moment-error bootstrap is itself a candidate for future v2 migration (issue #42 `wald_test_bootstrap`), but at least it doesn't trip its own deprecation warnings.

## Companion: Phase B-minimal

Per #47 this PR is the *follow-on cleanup*; the *companion* PR — Phase B-minimal, which makes `MomentRestriction.omega_hat` delegate to `dgp.sample_distribution.moment_covariance(theta, gi_jax)` when a DGP is attached — is in flight on a separate branch (`feature/omega_hat-delegates-to-dgp`).  This PR is **independent** of Phase B-minimal: the deprecation is purely additive (private mutators + warning emission); no functional change to omega_hat.  Either can land first.

## Test plan

- [x] `pytest tests/econometrics/test_moment_restriction.py tests/econometrics/test_with_clusters_with_weights_deprecation.py tests/econometrics/test_bootstrap.py::TestClusterStructural tests/econometrics/test_gmm.py -q` — 58 tests pass.
- [x] New deprecation-specific test file (7 tests) covers: warning emission on public methods, message references the v2 `EmpiricalDGP` path, private mutators do NOT warn, deprecated and private paths produce equivalent state.
- [x] `ruff check` / `black --check` / `mypy` clean on touched files.
- [ ] CI on push will exercise the full suite (slow Monte Carlo bootstrap tests left to CI).

## Docs

- `docs/release/notes_0.4.0a1.org`: new "Breaking / notable changes" entry with the migration recipe.
- `CLAUDE.md`: new "Three-Layer Responsibility Map" subsection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)