### PR TITLE
docs: separation-of-concerns principle + Phase C roadmap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,8 @@ Use canonical exceptions: `ManifoldError`, `RetractionError`, `ProjectionError`,
 
 `MomentRestriction.with_clusters` / `with_weights` are deprecated (issue #47): construct `EmpiricalDGP(sampling=ClusteredSampling(cluster_ids=...))` or `EmpiricalDGP(sampling=IIDSampling(weights=...))` plus `GMM(moment_func=g, dgp=dgp, ...)` instead.  Removal scheduled for v0.5.
 
+**Architectural principle to preserve**: ManifoldGMM should remain ignorant of sampling design (already true) and, eventually, of the data itself (Phase C target).  See `docs/design/separation_of_concerns.org` for the invariants contributors should preserve and `docs/design/v2_phase_c_data_ignorance.org` for the roadmap.
+
 ## Org-Mode Conventions
 - ASCII-safe LaTeX only (no Unicode math characters).
 - Display math: `\[ \]` or `\begin{equation}`.
@@ -31,7 +33,7 @@ Use canonical exceptions: `ManifoldError`, `RetractionError`, `ProjectionError`,
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **ManifoldGMM** (2162 symbols, 3363 relationships, 96 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **ManifoldGMM** (2846 symbols, 4397 relationships, 109 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
@@ -69,5 +71,12 @@ This project is indexed by GitNexus as **ManifoldGMM** (2162 symbols, 3363 relat
 | Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
 | Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
 | Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
+| Work in the Econometrics area (234 symbols) | `.claude/skills/generated/econometrics/SKILL.md` |
+| Work in the Geometry area (51 symbols) | `.claude/skills/generated/geometry/SKILL.md` |
+| Work in the Tests area (40 symbols) | `.claude/skills/generated/tests/SKILL.md` |
+| Work in the V2 area (35 symbols) | `.claude/skills/generated/v2/SKILL.md` |
+| Work in the Autodiff area (18 symbols) | `.claude/skills/generated/autodiff/SKILL.md` |
+| Work in the Tools area (12 symbols) | `.claude/skills/generated/tools/SKILL.md` |
+| Work in the Scripts area (9 symbols) | `.claude/skills/generated/scripts/SKILL.md` |
 
 <!-- gitnexus:end -->

--- a/docs/design/separation_of_concerns.org
+++ b/docs/design/separation_of_concerns.org
@@ -1,0 +1,122 @@
+#+TITLE: Separation of Concerns: ManifoldGMM and DGP_Protocol
+#+AUTHOR: Sue the Coder (with Ethan Ligon)
+#+DATE: 2026-05-26
+#+OPTIONS: toc:t num:nil ^:nil
+
+* Summary
+
+ManifoldGMM is an optimizer on a Riemannian manifold; DGP_Protocol is a
+container for the data and the sampling design that produced it.  The
+goal of the v2 split is that ManifoldGMM should remain ignorant of
+*where the data came from*, *how it was sampled*, and -- eventually --
+of the data values themselves.  All three pieces of knowledge live in
+the =DataGeneratingProcess= the user hands to the GMM at construction.
+
+The current v2 release has reached the first two of those three; the
+third is the Phase C target.  This note states the principle so
+contributors, refactorers, and downstream consumers can preserve it
+deliberately rather than rediscover it accidentally.
+
+* Why the split matters
+
+Three concrete pay-offs.
+
+** Inference adapts to the sampling design without estimator changes
+
+The cluster-robust sandwich, the iid sandwich, and the two-stage
+variance estimator are all members of the same family =Cov(g(theta))=
+under different sampling assumptions.  When that covariance is the
+DGP's responsibility, the estimator stops growing a case branch per
+design.  Adding =StratifiedSampling= to DGP_Protocol -- a hypothetical
+v0.5 feature -- requires no change to ManifoldGMM at all.
+
+** Power studies become first-class
+
+Generating synthetic data at a known =theta_0= and refitting on it is
+a one-liner once the DGP is its own object.  =ParametricDGP= +
+=gmm.with_dgp(...)= replaces the ad-hoc loops that v1 callers had to
+write.  This is the dominant pattern in the v2 examples
+(=tests/v2/bernoulli_v2.py=, =gaussian_mixture_v2.py=, etc.).
+
+** Estimator code stays small and testable
+
+ManifoldGMM doesn't import =cluster_ids=, doesn't carry a
+cluster-robust outer-product implementation, doesn't enumerate
+sampling-design cases.  Its test surface narrows to the optimizer, the
+manifold geometry, and the moment-function plumbing.  The DGP-side
+tests in =../DGP_Protocol/tests/= pin the covariance recipes
+independently and at machine precision.
+
+* Current state (Phase B-minimal)
+
+What ManifoldGMM consumes from a DGP today, and what it still touches
+directly.
+
+| Quantity                       | Delegated to DGP? | Where                                              |
+|--------------------------------+-------------------+----------------------------------------------------|
+| Raw data (=dgp.data=)          | No                | =gmm.py= line 2042 binds it into a MomentRestriction |
+| =g_bar(theta)=                 | No                | =MomentRestriction.gN= computes it via the user's =g= |
+| =Cov(g(theta))= (Omega)        | Yes               | =moment_restriction.py= line 509 -> =dgp._sd_moment_covariance= |
+| =Dg(theta)= (Jacobian)         | No                | JAX autodiff over =(theta, data)= in the backend   |
+| Bootstrap draws                | Yes               | =dgp.with_rng(s)= + child =.draw()= in =gmm.py= line 2483 |
+| Cluster ids / weights          | Yes               | Live on =dgp.sampling=; not on the restriction     |
+
+ManifoldGMM is *sampling-design-ignorant* -- the iid-vs-clustered
+distinction has been removed from the estimator entirely -- but it is
+not yet *data-ignorant*.  The point estimate and the Jacobian
+machinery still reach into =dgp.data= directly.
+
+* Target state (Phase C)
+
+Full data-ignorance.  ManifoldGMM consumes only =g_bar(theta)=,
+=Cov(g(theta))=, and =Dg(theta)= from the DGP and never sees the data
+matrix.  This requires DGP_Protocol to add two surfaces and
+ManifoldGMM to delegate two more code paths.  See
+=docs/design/v2_phase_c_data_ignorance.org= for the roadmap.
+
+Phase C is not on the critical path for any current consumer; it is
+the architectural endpoint that the current split is heading toward.
+
+* Invariants to preserve
+
+For contributors editing ManifoldGMM or the v2 GMM construction path.
+
+1. *No new direct reads of =dgp.data=, =dgp.sampling=, or any other
+   DGP-internal attribute* from ManifoldGMM code.  The two existing
+   uses (=dgp.data= at construction, =dgp.with_rng= / =draw= in
+   bootstrap) are the inventory; new code should call DGP methods that
+   return computed quantities, not raw fields.
+
+2. *No new conditional branches on sampling design.*  ManifoldGMM
+   should never =isinstance(dgp.sampling, ClusteredSampling)= or
+   equivalent.  When such a check would be useful, the right move is
+   to add a method to =SamplingDesign= that the estimator can call
+   uniformly.
+
+3. *Inference helpers go through the DGP.*  =Cov(g(theta))= comes from
+   =dgp._sd_moment_covariance= (Phase B-minimal); future helpers
+   (e.g., HAC variants, two-stage cluster) should follow the same
+   route.
+
+4. *v1 surfaces stay frozen.*  =MomentRestriction(g, data)= remains a
+   public constructor for users who don't want to wrap their data in a
+   DGP.  Internally, that path is observationally
+   =EmpiricalDGP(observation=data, sampling=IIDSampling())=.  v1
+   callers should never see a behaviour change from a v2 refactor.
+
+5. *Deprecations point at the v2 idiom.*
+   =MomentRestriction.with_clusters= / =with_weights= already issue a
+   =DeprecationWarning= pointing at =EmpiricalDGP=; any new v1 API
+   that gets retired should do the same.
+
+* References
+
+- =docs/design/v2_dgp.org= -- full v2 design note (deeper history,
+  motivation, consumer surface).
+- =docs/design/v2_phase_c_data_ignorance.org= -- Phase C roadmap.
+- =docs/standards/naming_notation.org= -- canonical math-to-code
+  mappings used by both projects.
+- =../DGP_Protocol/AGENTS.md= -- sibling project's contributor guide.
+- Manski (1988), /Analog Estimation Methods in Econometrics/, Chapman
+  and Hall.  The framing of the estimator as a functional of an
+  empirical distribution.

--- a/docs/design/v2_phase_c_data_ignorance.org
+++ b/docs/design/v2_phase_c_data_ignorance.org
@@ -1,0 +1,180 @@
+#+TITLE: v2 Phase C: Full Data-Ignorance for ManifoldGMM
+#+AUTHOR: Sue the Coder (with Ethan Ligon)
+#+DATE: 2026-05-26
+#+OPTIONS: toc:t num:nil ^:nil
+
+* Summary
+
+Phase C closes the remaining data-coupling gap in the v2 GMM /
+DGP_Protocol split.  Today ManifoldGMM still reads =dgp.data= at
+construction and computes =Dg(theta)= via JAX autodiff over
+=(theta, data)=.  In Phase C those two responsibilities move to the
+DGP, and ManifoldGMM consumes only three quantities:
+
+#+begin_src python
+  g_bar    = dgp.gbar(theta, g)         # E[g(theta, X)] under dgp
+  Omega    = dgp.moment_covariance(theta, g, centered=True)
+  Dg       = dgp.gbar_jacobian(theta, g)
+#+end_src
+
+After Phase C, =MomentRestriction= becomes a pure container for
+=(g, manifold, backend)= -- no data, no Jacobian wiring, no autodiff
+plumbing.  The GMM's =estimate()= loop reads those three quantities
+from the DGP and runs the existing optimizer unchanged.
+
+This is a *roadmap*, not an implementation plan.  Nothing here is on
+the critical path; Phase C-minimal can wait until a consumer needs it.
+
+* Goal
+
+After Phase C, an instrumented test that asserts =dgp.data= is never
+accessed from ManifoldGMM code during =estimate()= should pass.
+Equivalently, replacing =dgp.data= with a property that raises
+=AssertionError= should leave =estimate()= -- and bootstrap, and
+inference -- still working.
+
+* New DGP-side interfaces
+
+Two additions to =DataGeneratingProcess= (or to a companion mixin
+that =EmpiricalDGP=, =ParametricDGP=, and =TwoStageDGP= can adopt).
+
+** =gbar(theta, g)=
+
+The analog estimator's moment functional evaluated at =theta=.  For
+=EmpiricalDGP=, this is =g(theta, self.data).mean(axis=0)= (with
+optional sampling-design weights).  For =ParametricDGP=, this is the
+closed-form expectation if available, else Monte Carlo to a target
+tolerance.
+
+The interesting case is =TwoStageDGP= (or hierarchical sampling more
+generally): =gbar= needs to respect the design weights that
+=ClusteredSampling= or =StratifiedSampling= carries, the same way
+=moment_covariance= already does in Phase B.
+
+** =gbar_jacobian(theta, g)=
+
+The derivative of =gbar= with respect to =theta=, in the embedded /
+ambient parameterization (the manifold-side projection stays a
+ManifoldGMM concern).  Two natural implementations:
+
+- *Empirical / sample-based*: JAX autodiff over =g(theta, self.data)=,
+  averaged with the design weights.  This is what the current
+  ManifoldGMM backend does, lifted into the DGP.
+- *Analytic / parametric*: when =gbar= has a closed form, its
+  Jacobian usually does too.  =ParametricDGP= can override.
+
+The Jacobian is the natural companion to =gbar=: any DGP that owns
+=gbar= for a given =g= can answer =gbar_jacobian= by autodiff over
+its own implementation, regardless of whether =gbar= was analytic or
+sample-based.
+
+* ManifoldGMM-side refactor
+
+Three changes, each independently shippable.
+
+1. *Replace =MomentRestriction.gN(theta)=* with =dgp.gbar(theta, g)=
+   at the GMM call sites.  Restriction-internal callers (legacy v1
+   path) keep the current implementation.
+2. *Replace the autodiff Jacobian* (currently wired through the
+   pymanopt backend on =cost(theta) = gbar^T W gbar=) with a
+   composition: =dgp.gbar_jacobian(theta, g)= for the inner =Dg=,
+   then ManifoldGMM does the chain rule and the manifold projection.
+3. *Drop the =data=dgp.data= argument* from the synthesized
+   MomentRestriction in the v2 path.  =MomentRestriction= without
+   data becomes the canonical v2 container for =(g, manifold,
+   backend)=.
+
+A v1-compatibility shim keeps =MomentRestriction(g, data)= working:
+internally it constructs an =EmpiricalDGP(observation=data,
+sampling=IIDSampling())= and threads the new DGP-side calls through.
+
+* Open questions
+
+Things to settle before Phase C-minimal lands.
+
+** JAX tracing across the DGP boundary
+
+The current omega_hat delegation hands a JAX-traced =theta= to
+=dgp._sd_moment_covariance=, which returns a JAX array.  For =gbar=
+and =gbar_jacobian= the same pattern should work, but the call chain
+is deeper: =gmm.estimate= -> =gbar= -> user's =g= -> autodiff back.
+The DGP needs to either pass =theta= through unchanged or document
+which call paths support tracing.  The Phase B work hit this
+(=#26135b5= had to switch from =sample_distribution.moment_covariance=
+to =_sd_moment_covariance= to avoid an MC fallback under tracing);
+Phase C should plan around it from the start rather than discover it
+under load.
+
+** ParametricDGP without bound data
+
+A pure =ParametricDGP= (no =observation=) has no data to take an
+empirical mean over.  =gbar= for such a DGP should either (a) return
+the analytic expectation when available, or (b) raise a clear error
+pointing at =with_data(dgp.draw())=.  The current v2 GMM already
+requires a bound realization (=dgp.data is not None=, gmm.py line
+2024); Phase C inherits the same constraint.
+
+** Backend ownership of the autodiff
+
+The current MomentRestriction holds the autodiff backend (=jax= /
+=numpy=) and lifts =g= into JIT-compiled form.  After Phase C, that
+backend belongs at the DGP-side =gbar_jacobian= -- which means
+=EmpiricalDGP= grows a backend argument, or the GMM passes a backend
+hint through each call.  Probably the cleanest answer is the former:
+DGPs declare their backend; the GMM honours it.
+
+** Penalty-on-theta interaction
+
+=PenaltyStrategy= attaches a =penalty(theta)= term to the GMM cost
+that depends only on =theta=, never on data.  Phase C doesn't touch
+penalties at all; they stay on the GMM where they already are.  Worth
+noting explicitly so a future contributor doesn't try to relocate
+them.
+
+* Phase C-minimal staging
+
+Mirror the Phase B-minimal pattern: ship the smallest delegation that
+proves the architecture, then layer on the rest.
+
+1. *Phase C-minimal*: =EmpiricalDGP.gbar= and =EmpiricalDGP.gbar_jacobian=
+   ship in DGP_Protocol with the simplest possible implementation
+   (mean of =g=, JAX autodiff).  ManifoldGMM gains an opt-in code
+   path -- gated by a constructor flag like =use_dgp_gradients=True=
+   -- that uses them.  Default off; tests pin byte-parity with the
+   current path.
+
+2. *Phase C-1*: =ParametricDGP= and =TwoStageDGP= grow analytic
+   overrides where they exist.  ManifoldGMM's opt-in flag becomes
+   the default for v2 callers.
+
+3. *Phase C-2*: The legacy autodiff backend in =MomentRestriction= is
+   trimmed to the v1 path only; v2 paths route exclusively through
+   the DGP.
+
+4. *Phase C-final*: =MomentRestriction= without data becomes the
+   canonical v2 container.  The =dgp.data= access at GMM construction
+   is removed.
+
+Each stage is its own PR with its own byte-parity tests against the
+prior path.
+
+* Out of scope
+
+- *Adding new sampling designs.*  =StratifiedSampling=, =HACSampling=,
+  etc. are DGP-side work, independent of Phase C.  Phase C should
+  make them easier to add, but doesn't add any itself.
+- *Removing the v1 surface.*  =MomentRestriction(g, data)= +
+  =GMM(restriction, ...)= stays public.  Phase C is purely an
+  internal rewiring of the v2 path.
+- *Performance.*  Phase C is an architectural cleanup, not an
+  optimization.  If the DGP-side autodiff turns out to be slower than
+  the current path, that's a Phase C-3 concern with its own benchmarks
+  and decisions.
+
+* References
+
+- =docs/design/separation_of_concerns.org= -- the principle Phase C
+  completes.
+- =docs/design/v2_dgp.org= -- v2 design note (Phase A + Phase B).
+- =86b7851= and =26135b5= -- Phase B-minimal commits (the omega_hat
+  delegation that established the pattern).

--- a/tests/v2/__init__.py
+++ b/tests/v2/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the v2 DGP-based GMM construction path."""


### PR DESCRIPTION
## Summary

- New `docs/design/separation_of_concerns.org` pins the architectural goal of the v2 split (ManifoldGMM as pure optimizer, DGP_Protocol as owner of data + sampling) and lists five invariants contributors should preserve.
- New `docs/design/v2_phase_c_data_ignorance.org` sketches the roadmap for the remaining migration: two new DGP-side interfaces (`gbar`, `gbar_jacobian`), the ManifoldGMM-side refactor, four open questions, and a four-stage Phase C-minimal → Phase C-final ladder mirroring the Phase B-minimal pattern from #49.
- `CLAUDE.md` gains a one-paragraph callout in the existing Three-Layer Responsibility Map section pointing at both docs.

## Motivation

The v2 split has reached a stable intermediate point — ManifoldGMM is **sampling-design-ignorant** (per #46 + #49) but still reads `dgp.data` directly at construction (`gmm.py:2042`) and computes `Dg(theta)` via JAX autodiff over `(theta, data)`.  The architectural endpoint — full data-ignorance, where ManifoldGMM consumes only `{gbar(theta), Cov(g(theta)), Dg(theta)}` — isn't documented anywhere as a north star.  Without that, the next contributor (human or agent) editing the v2 path can drift away from the separation without noticing.

## What this PR does *not* do

- No code changes to `src/`.  Pure docs + a CLAUDE.md text update.
- No commitment to a Phase C timeline.  The roadmap is a target, not a sprint.
- No deprecation of any v1 surface.  `MomentRestriction(g, data)` + `GMM(restriction, ...)` stays public.

## Also folded in

- `tests/v2/__init__.py` gains a one-line docstring to silence the GitNexus `Provider must emit @scope.module capture` warning that fires on zero-byte init files.
- CLAUDE.md's auto-generated GitNexus block reflects the recent reindex (2,162 → 2,846 symbols, plus the new generated cluster-skills table).

## Test plan

- [ ] Render `separation_of_concerns.org` and `v2_phase_c_data_ignorance.org` in an Org-mode-aware viewer; confirm structure, cross-links, and ASCII-safe LaTeX.
- [ ] Skim CLAUDE.md to confirm the callout reads naturally and points at the right files.
- [ ] No code changed, so `make check` is not exercised by this PR; CI should pass trivially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)