### PR TITLE
release prep: v0.4.0 stable -- DGP_Protocol PyPI dep + release notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,17 +15,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # ``pyproject.toml`` pins DGP_Protocol via a local path
-      # (``../DGP_Protocol``) during the pre-release window; CI must
-      # checkout the sibling repo for ``poetry install`` to resolve.
-      # Shallow clone is sufficient -- we only need the package
-      # source for the editable install.  Switch to a PyPI version
-      # constraint once DGP_Protocol publishes a release and remove
-      # this step.
-      - name: Checkout DGP_Protocol (sibling, for local-path dep)
-        run: |
-          git clone --depth 1 https://github.com/ligon/DGP_Protocol.git ../DGP_Protocol
-
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ Use canonical exceptions: `ManifoldError`, `RetractionError`, `ProjectionError`,
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **ManifoldGMM** (2846 symbols, 4397 relationships, 109 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **ManifoldGMM** (3000 symbols, 4714 relationships, 116 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
@@ -71,10 +71,10 @@ This project is indexed by GitNexus as **ManifoldGMM** (2846 symbols, 4397 relat
 | Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
 | Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
 | Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
-| Work in the Econometrics area (234 symbols) | `.claude/skills/generated/econometrics/SKILL.md` |
+| Work in the Econometrics area (255 symbols) | `.claude/skills/generated/econometrics/SKILL.md` |
+| Work in the V2 area (63 symbols) | `.claude/skills/generated/v2/SKILL.md` |
 | Work in the Geometry area (51 symbols) | `.claude/skills/generated/geometry/SKILL.md` |
 | Work in the Tests area (40 symbols) | `.claude/skills/generated/tests/SKILL.md` |
-| Work in the V2 area (35 symbols) | `.claude/skills/generated/v2/SKILL.md` |
 | Work in the Autodiff area (18 symbols) | `.claude/skills/generated/autodiff/SKILL.md` |
 | Work in the Tools area (12 symbols) | `.claude/skills/generated/tools/SKILL.md` |
 | Work in the Scripts area (9 symbols) | `.claude/skills/generated/scripts/SKILL.md` |

--- a/docs/release/notes_0.4.0.org
+++ b/docs/release/notes_0.4.0.org
@@ -1,0 +1,120 @@
+#+TITLE: Release Notes -- v0.4.0
+#+AUTHOR: ManifoldGMM Maintainers
+#+DATE: <2026-05-27 Wed>
+#+OPTIONS: toc:nil num:nil
+
+* Summary
+
+The v2 GMM consumer surface -- =GMM(moment_func, dgp, manifold,
+...)= driven by a =DataGeneratingProcess= -- promotes from
+=v0.4.0a1= (planned) to stable.  The v1
+=GMM(restriction, ...)= surface stays public and bit-identical; v2
+is the recommended path going forward.
+
+This is a delta from the planned =v0.4.0a1= notes.  See
+=docs/release/notes_0.4.0a1.org= for the full v2 launch feature
+list; this document records what changed between the alpha
+specification and the stable cut.
+
+* Highlights
+
+** Cluster-wild bootstrap on v2 GMMResult: bug fix (#54)
+
+=MomentWildBootstrap= and =k_statistic_bootstrap_for_result= both
+resolved cluster ids from =restriction.clusters= -- the v1-only
+attribute, always =None= on v2-constructed results.  Cluster-wild
+Rademacher resampling silently degraded to per-observation iid
+signs on clustered v2 results, producing the wrong bootstrap
+distribution.
+
+The fix follows =docs/design/v2_dgp.org= lines 191-199: when
+=restriction.clusters is None=, fall back to
+=restriction._dgp.sampling.cluster_ids= before defaulting to iid.
+Encapsulated in a new module-level helper
+=_v2_dgp_cluster_ids(gmm_result)= so both call sites share the
+lookup logic.
+
+Behaviour matrix after the fix:
+
+| Caller                              | Before        | After          |
+|-------------------------------------+---------------+----------------|
+| v1 with =restriction.clusters= set  | cluster_wild  | cluster_wild   |
+| v1 without clusters                 | iid           | iid            |
+| v2 with =ClusteredSampling=         | iid (bug)     | cluster_wild   |
+| v2 with default / =IIDSampling=     | iid           | iid            |
+| Explicit =clusters== kwarg          | wins          | wins           |
+
+** v1<->v2 numeric parity battery (#54)
+
+Twelve fast tests + one slow under =tests/v2/test_parity_*.py=
+pinning numerical equivalence between the v1
+(=MomentRestriction=-based) and v2 (DGP-based) construction paths.
+Covers:
+
+- Clustered =theta_hat= (iid + clustered just-identified, clustered
+  overid + two-step).
+- Wild bootstrap byte-parity at fixed =base_seed= (iid + clustered).
+- J / K / Wald inference statistics on shared =theta_hat=.
+- K-statistic bootstrap on clustered designs.
+- Two-step, iterated GMM, and CUE+ridge weighting.
+- Cross-methodology check (slow): wild bootstrap vs raw-data
+  =gmm.bootstrap()= SE agreement at large N.
+
+The parity tests caught the cluster-wild bootstrap bug above; future
+v2 maintenance gains a standing regression net.
+
+** Separation-of-concerns architectural docs (#53)
+
+Two new design notes pin the v2 architecture's north star and its
+roadmap:
+
+- =docs/design/separation_of_concerns.org= -- the architectural
+  principle (ManifoldGMM as pure optimizer; DGP_Protocol owns data
+  + sampling), the current state table (what is delegated vs what
+  still touches =dgp.data=), and five invariants contributors should
+  preserve.
+- =docs/design/v2_phase_c_data_ignorance.org= -- the roadmap for
+  full data-ignorance.  Sketches the two new DGP-side interfaces
+  (=gbar=, =gbar_jacobian=), the ManifoldGMM-side refactor, four
+  open questions, and a four-stage Phase C-minimal -> Phase C-final
+  ladder.  Tracked as issue #55.
+
+=CLAUDE.md= gains a callout in the Three-Layer Responsibility Map
+section pointing at both docs, so AI agents working on v2 code
+discover the principle without chasing the design history.
+
+** DGP_Protocol dependency: PyPI
+
+=pyproject.toml= switches the =DGP_Protocol= dependency from the
+local path (=../DGP_Protocol=, used during the pre-release window)
+to the PyPI release =>=0.1.0a0=.  The CI =Checkout DGP_Protocol
+sibling= workaround (PR #50) is dropped.
+
+* Smaller items
+
+- =tests/v2/__init__.py= gains a docstring (silences a GitNexus
+  =Provider must emit @scope.module capture= warning on the empty
+  package init).
+- DGP_Protocol issue #2 filed and fixed (DGP_Protocol PR #3):
+  =EmpiricalDGP(sampling=None)= now coerces to =IIDSampling()=
+  instead of crashing inside =omega_hat=.  Not user-facing for
+  ManifoldGMM consumers but eliminates a footgun encountered during
+  the parity-test work.
+
+* Compatibility
+
+- v1 callers using =GMM(restriction, ...)= are unchanged; tests
+  pinning v1 behaviour all pass.
+- =MomentRestriction.with_clusters= / =with_weights= remain
+  deprecated (introduced in =v0.4.0a1=); removal scheduled for
+  =v0.5=.
+- v2 callers gain the cluster-wild bootstrap fix automatically.
+
+* References
+
+- PR #53 -- separation-of-concerns docs + Phase C roadmap.
+- PR #54 -- v1<->v2 parity tests + cluster-wild bootstrap fix.
+- DGP_Protocol PR #3 -- =EmpiricalDGP(sampling=None)= coercion
+  (closes upstream issue #2).
+- Issue #55 -- Phase C tracking issue.
+- =docs/release/notes_0.4.0a1.org= -- v2 launch feature list.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,9 @@ packages = [{ include = "manifoldgmm", from = "src" }]
 python = ">=3.11,<4.0"
 pymanopt = { git = "https://github.com/pymanopt/pymanopt.git" }
 datamat = ">=0.2.0a1"
-# Local path while DGP_Protocol is pre-release; switch to a version
-# constraint once it lands on PyPI.
-DGP_Protocol = { path = "../DGP_Protocol", develop = true }
+# Pinned to the PyPI release.  Was a local path dep during the
+# pre-release window; switched to PyPI once 0.1.0a0 published.
+DGP_Protocol = ">=0.1.0a0"
 jax = ">=0.4.25"
 
 [tool.poetry.extras]


### PR DESCRIPTION
## Summary

DGP_Protocol just published \`0.1.0a0\` to PyPI.  This PR moves ManifoldGMM out of the pre-release window in three coupled changes:

- **\`pyproject.toml\`**: swap \`DGP_Protocol = { path = \"../DGP_Protocol\", develop = true }\` for \`DGP_Protocol = \">=0.1.0a0\"\`.  The \`[project]\` dependencies section (PEP 621) already had \`DGP_Protocol>=0.1.0a0\`; this aligns Poetry-managed installs with the static metadata.
- **\`.github/workflows/ci.yml\`**: drop the \`Checkout DGP_Protocol sibling\` step (added in PR #50, commit \`7beb580\`).  CI now resolves DGP_Protocol from PyPI via the normal \`poetry install --with dev\` path.  The skip-slow pytest step is unchanged.
- **\`docs/release/notes_0.4.0.org\`**: new file.  Stable cut delta from the planned \`v0.4.0a1\` notes (which were content-complete but never released).  Documents the cluster-wild bootstrap fix (#54), the v1↔v2 parity battery (#54), the separation-of-concerns docs (#53), and the DGP_Protocol PyPI dep swap.  The historical \`notes_0.4.0a1.org\` is left in place as the v2 launch feature list.

\`CLAUDE.md\` change is the auto-generated GitNexus block update from the post-#54 reindex (2846 → 3000 symbols; the V2 cluster grew from 35 → 63 symbols with the new parity tests).

## Local verification

- [x] \`poetry install --with dev\` resolves \`dgp-protocol 0.1.0a0\` from PyPI into \`.venv/lib/python3.11/site-packages/dgp_protocol/\` (not the local mirror).
- [x] \`poetry run pytest tests/v2/ -m 'not slow'\` — 52 passed.
- [x] \`poetry run ruff check . && poetry run black --check . && poetry run mypy src tests\` — all clean.

## Not done in this PR (deliberate — release-day decisions)

- **Version bump in \`pyproject.toml\`** (still \`0.3.0a3\`).  Maintainer bumps to \`0.4.0\` on the tag/publish.
- **Git tag + GitHub release + PyPI publish.**

## Pre-existing item surfaced but out of scope

\`poetry.lock\` is gitignored (line 15 of \`.gitignore\`), so the CI cache key \`hashFiles('poetry.lock')\` resolves to empty and the cache is effectively a no-op.  Worth a separate decision (commit the lock file vs change the cache key strategy) — doesn't block the dep swap, just leaves CI re-resolving fresh on every run.

## Companion PRs / issues

- DGP_Protocol PR #3 — \`EmpiricalDGP(sampling=None)\` coercion (closes upstream issue #2).  Independent; merge order doesn't matter for this PR.
- ManifoldGMM issue #55 — Phase C tracking issue (full data-ignorance for ManifoldGMM).  No PR yet; v0.5+ roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)